### PR TITLE
fix: stop incidental git operations from installing dotfiles into the real $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,15 @@ nothing stronger: no commit-blocking hook, no read-only file attributes. Refuse
 and warn is enough. (An unreachable remote fails the same way; the checkout is
 then simply stale, which is harmless.)
 
+**The pull is also non-destructive to local tags.** Both installers run it as
+`git -c fetch.pruneTags=false pull --ff-only origin`. Without that override, a
+global `fetch.pruneTags = true` (a reasonable thing to have set generally)
+makes an ordinary `--ff-only` pull silently delete every local tag not on
+`origin` — even a no-op "Already up to date" pull. `fetch.prune` for
+remote-tracking branches is left at whatever it's set to; only tag deletion is
+disabled, since that's the part with no legitimate reason to happen as a side
+effect of relinking dotfiles.
+
 **Why a WSL-driven Windows box still needs a real checkout on local disk.**
 When all the editing happens inside WSL it's tempting to keep exactly one
 checkout there and point Windows at it over `\\wsl.localhost\…`. That doesn't
@@ -448,6 +457,35 @@ immediately, leaving the outer run to do the relinking once. The variable is
 scoped to that single git invocation and restored straight after, so a `git
 pull` you type by hand still triggers a normal sync.
 
+**The hooks only fire on a checkout that was deliberately installed.** Every
+git operation above (`git worktree add`, `git clone -c core.hooksPath=hooks`,
+even an ordinary pull in an unrelated checkout that happens to inherit
+`core.hooksPath`) is a *potential* trigger, but the point of the installer is
+to touch `$HOME` on purpose, not incidentally. So the very first thing
+`hooks/_dispatch.sh` does — right after the re-entrancy guard above, and
+before it even looks at which platform it's on — is check for an install
+receipt: a plain text file at `~/.local/state/dotfiles/install-root`
+recording the physically-resolved path of whichever checkout `install.py`
+was last deliberately run from (that command being `bash install.sh` /
+`install.ps1`, run by hand, not a hook). It lives outside this repo (so
+cloning it doesn't carry a stale receipt along) and outside `.git/config`
+(so worktrees, which share that file with their primary checkout, don't
+inherit one either).
+
+If that file doesn't exist, or names a different checkout than the one the
+hook is running from, `_dispatch.sh` prints one line explaining why and exits
+without running anything. Concretely: a fresh `git clone` (even one seeded
+with `-c core.hooksPath=hooks`) no-ops on its first checkout because nothing
+has ever installed into that `$HOME` yet; a `git worktree add` off a
+previously-installed primary checkout no-ops too, because the receipt names
+the primary's path, not the worktree's. The canonical checkout itself is
+unaffected — its receipt matches, so `git pull`/`git rebase`/branch switches
+there keep triggering the installer exactly as described above. If you
+deliberately relocate a checkout that used to be canonical (`mv`, a fresh
+clone replacing the old directory, ...), re-run `bash install.sh` /
+`install.ps1` there by hand once to rewrite the receipt and re-arm the hooks
+for the new path.
+
 ## Structure
 
 ```
@@ -460,10 +498,12 @@ dotfiles/
 │   ├── .gitignore_global
 │   └── ensure-gcm.sh    ← installs a credential.helper on Linux/devcontainer if none exists, see secrets/README.md
 ├── hooks/                       ← core.hooksPath target, wired up by the installer
-│   ├── _dispatch.sh              ← shared logic: re-runs install.ps1/install.sh
+│   ├── _dispatch.sh              ← shared logic: re-runs install.ps1/install.sh,
+│   │                                gated on the install receipt, see above
 │   ├── post-checkout
 │   ├── post-merge
-│   └── post-rewrite
+│   ├── post-rewrite
+│   └── pre-commit                ← this repo's own commit-time checks
 ├── shell/
 │   ├── .bashrc
 │   ├── .bash_profile

--- a/hooks/_dispatch.sh
+++ b/hooks/_dispatch.sh
@@ -25,6 +25,64 @@ if [ -n "${DOTFILES_INSTALL_ACTIVE:-}" ]; then
   exit 0
 fi
 
+# ── NORMALIZE:BEGIN ─────────────────────────────────────────────────────────
+# _dotfiles_normalize_win_path <path>
+#
+# Normalizes a receipt path for comparison. On native Windows the two sides
+# of the receipt check come from different toolchains and render the *same*
+# physical directory two different ways:
+#   - install.py runs under native Windows Python and writes the Win32 form,
+#     e.g. C:\Users\jeremy\dotfiles
+#   - this hook runs under Git-for-Windows' MSYS sh and computes DOTFILES_DIR
+#     with `pwd -P`, giving the POSIX/MSYS form, e.g. /c/Users/jeremy/dotfiles
+# A raw string compare of those two can never match, so the receipt guard
+# would fail closed forever on Windows -- safe, but it permanently disables
+# the sync this guard exists to allow. This function maps either form to one
+# canonical, case-folded representation (Windows paths are case-insensitive)
+# so both sides can be compared after going through it.
+#
+# Prefers `cygpath -u` (ships alongside this very sh.exe on Git for Windows,
+# and correctly handles UNC paths, subst'd drives, 8.3 names, etc.). Falls
+# back to a pure-shell translation of the common "C:\foo\bar" shape if
+# cygpath isn't on PATH, so the guard still works in a minimal MSYS
+# environment. On any unrecognized shape, or a cygpath failure, this prints
+# nothing and returns non-zero -- callers MUST treat that as "could not
+# verify" and fail closed (skip), never as "matches".
+#
+# Deliberately NOT invoked at all outside the MINGW/MSYS branch below: on
+# Linux/macOS/WSL both sides already come from the same POSIX toolchain, so
+# the existing case-sensitive raw compare is left untouched.
+_dotfiles_normalize_win_path() {
+  in=$1
+  [ -n "$in" ] || return 1
+
+  case "$in" in
+    [A-Za-z]:\\* | [A-Za-z]:/*)
+      # Win32 drive-letter form.
+      if command -v cygpath >/dev/null 2>&1; then
+        out=$(cygpath -u -- "$in" 2>/dev/null) || return 1
+      else
+        drive=$(printf '%s' "$in" | cut -c1 | tr '[:upper:]' '[:lower:]')
+        rest=$(printf '%s' "$in" | cut -c3- | tr '\\' '/')
+        out="/${drive}${rest}"
+      fi
+      ;;
+    /*)
+      # Already POSIX/MSYS form.
+      out=$in
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  [ -n "$out" ] || return 1
+  printf '%s' "$out" | tr '[:upper:]' '[:lower:]'
+}
+# ── NORMALIZE:END ───────────────────────────────────────────────────────────
+
+UNAME_S="$(uname -s)"
+
 # pwd -P (not plain pwd) so a symlinked path to this checkout doesn't cause a
 # false mismatch against the physically-resolved path install.py recorded.
 DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd -P)"
@@ -53,12 +111,36 @@ if [ ! -f "$RECEIPT" ]; then
   exit 0
 fi
 RECORDED_DIR="$(cat "$RECEIPT" 2>/dev/null || true)"
-if [ "$RECORDED_DIR" != "$DOTFILES_DIR" ]; then
+
+# See _dotfiles_normalize_win_path above: on Windows, normalize both sides to
+# one canonical, case-folded form before comparing so a receipt written by
+# native Windows Python (Win32 form) still matches this MSYS shell's own
+# POSIX-form DOTFILES_DIR. Fail closed (skip) if normalization can't be done
+# for either side -- never fall through and run the installer on an
+# unverified match. Elsewhere, compare the raw strings exactly as before.
+case "$UNAME_S" in
+  MINGW*|MSYS*)
+    if ! CMP_RECORDED="$(_dotfiles_normalize_win_path "$RECORDED_DIR")"; then
+      echo "dotfiles: could not normalize install receipt path '$RECORDED_DIR' for comparison — skipping hook-triggered install (fail closed; run 'bash install.sh' here by hand to re-arm)"
+      exit 0
+    fi
+    if ! CMP_DOTFILES="$(_dotfiles_normalize_win_path "$DOTFILES_DIR")"; then
+      echo "dotfiles: could not normalize checkout path '$DOTFILES_DIR' for comparison — skipping hook-triggered install (fail closed)"
+      exit 0
+    fi
+    ;;
+  *)
+    CMP_RECORDED="$RECORDED_DIR"
+    CMP_DOTFILES="$DOTFILES_DIR"
+    ;;
+esac
+
+if [ "$CMP_RECORDED" != "$CMP_DOTFILES" ]; then
   echo "dotfiles: install receipt points at '$RECORDED_DIR', this checkout is '$DOTFILES_DIR' — skipping hook-triggered install (run 'bash install.sh' here by hand to re-arm)"
   exit 0
 fi
 
-case "$(uname -s)" in
+case "$UNAME_S" in
   MINGW*|MSYS*)
     command -v pwsh >/dev/null 2>&1 && pwsh -NoLogo -NoProfile -File "$DOTFILES_DIR/install.ps1" -SkipWSL
     ;;

--- a/hooks/_dispatch.sh
+++ b/hooks/_dispatch.sh
@@ -25,7 +25,38 @@ if [ -n "${DOTFILES_INSTALL_ACTIVE:-}" ]; then
   exit 0
 fi
 
-DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# pwd -P (not plain pwd) so a symlinked path to this checkout doesn't cause a
+# false mismatch against the physically-resolved path install.py recorded.
+DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd -P)"
+
+# Canonical-install-receipt guard — must run before the uname case below so it
+# covers Windows/MINGW too, not just the Unix branch.
+#
+# A `git worktree add` shares the primary checkout's .git/config, including
+# core.hooksPath=hooks; since `hooks` is a relative path, it resolves inside
+# whichever checkout this hook actually fires from. Left unguarded, a branch
+# switch inside a brand-new, possibly-unreviewed worktree installs that
+# worktree's content into the real $HOME. Same story for
+# `git clone -c core.hooksPath=hooks <repo> <dir>`, which persists the setting
+# into a fresh clone and fires on its own first checkout.
+#
+# The guard: only run when $HOME already holds a receipt (written by a
+# deliberate install.sh/install.py run — see install.py) naming *this*
+# checkout as the one it was installed from. No receipt, or a receipt naming
+# a different checkout, is a silent no-op: a machine that has never had a
+# deliberate install must never get one from an incidental git operation. A
+# checkout that's been legitimately relocated re-arms itself by re-running
+# `bash install.sh` by hand, which rewrites the receipt to the new path.
+RECEIPT="$HOME/.local/state/dotfiles/install-root"
+if [ ! -f "$RECEIPT" ]; then
+  echo "dotfiles: no install receipt at $RECEIPT for checkout $DOTFILES_DIR — skipping hook-triggered install (this \$HOME has never had a deliberate install)"
+  exit 0
+fi
+RECORDED_DIR="$(cat "$RECEIPT" 2>/dev/null || true)"
+if [ "$RECORDED_DIR" != "$DOTFILES_DIR" ]; then
+  echo "dotfiles: install receipt points at '$RECORDED_DIR', this checkout is '$DOTFILES_DIR' — skipping hook-triggered install (run 'bash install.sh' here by hand to re-arm)"
+  exit 0
+fi
 
 case "$(uname -s)" in
   MINGW*|MSYS*)

--- a/install.ps1
+++ b/install.ps1
@@ -170,7 +170,7 @@ if (-not $pyPath) {
 # it in all three.
 log "Updating this checkout from origin (fast-forward only)..."
 if ($DryRun) {
-  Write-Host "  git -C $DOTFILES pull --ff-only origin"
+  Write-Host "  git -c fetch.pruneTags=false -C $DOTFILES pull --ff-only origin"
 } elseif (-not (Get-Command git -ErrorAction SilentlyContinue)) {
   warn "git not on PATH — skipping self-update, continuing with the install"
 } else {
@@ -217,7 +217,13 @@ if ($DryRun) {
       # Output captured rather than printed so a routine up-to-date run stays
       # quiet, consistent with the *>$null suppression in the Scoop section;
       # it is echoed back only when the pull fails and you need to see why.
-      $pullOutput = @(git -C $DOTFILES pull --ff-only origin 2>&1)
+      # fetch.pruneTags=false overrides a global fetch.pruneTags=true for this
+      # one pull: that global setting makes an ordinary --ff-only pull
+      # silently delete every local tag not on origin, even on a no-op
+      # "Already up to date" pull. fetch.prune (remote-tracking branches) is
+      # left alone — only tag deletion is destructive to state a pull has no
+      # business touching.
+      $pullOutput = @(git -c fetch.pruneTags=false -C $DOTFILES pull --ff-only origin 2>&1)
       $pullExit   = $LASTEXITCODE
     }
   } catch {

--- a/install.py
+++ b/install.py
@@ -282,6 +282,20 @@ if DRY_RUN:
 else:
     receipt = HOME / ".local" / "state" / "dotfiles" / "install-root"
     receipt.parent.mkdir(parents=True, exist_ok=True)
+    # Refuse to write through a symlink. write_text() opens with plain
+    # open(..., "w"), which follows symlinks and truncates whatever they
+    # point at -- a symlink planted at the receipt path (or its immediate
+    # parent dir) before this runs would turn a routine install into an
+    # attacker-chosen arbitrary-file overwrite. Same awareness as
+    # write_through_symlink() above, applied in the opposite direction: that
+    # helper deliberately follows a symlink because a user's own dotfile
+    # symlinks are meant to be written through; this receipt has no
+    # legitimate reason to ever be a symlink, so we refuse instead.
+    if receipt.parent.is_symlink():
+        error(f"{receipt.parent} is a symlink — refusing to write install receipt through it")
+        sys.exit(1)
+    if receipt.is_symlink():
+        receipt.unlink()
     receipt.write_text(f"{DOTFILES}\n", encoding="utf-8")
     success(f"Recorded install root ({DOTFILES}) -> {receipt}")
 

--- a/install.py
+++ b/install.py
@@ -262,6 +262,29 @@ if existing_global_hooks == str(DOTFILES / "git" / "global-hooks"):
         run("git", "config", "--global", "--unset", "core.hooksPath")
         success("Removed global core.hooksPath (identity guard retired in favor of shell/doctor.sh)")
 
+# ── install receipt ──────────────────────────────────────────────────────────
+# Records which checkout this $HOME was deliberately installed from, so
+# hooks/_dispatch.sh can tell a real install from an incidental one. A `git
+# worktree add` shares the primary checkout's .git/config -- including the
+# core.hooksPath just set above -- and since `hooks` is a relative path it
+# resolves inside whichever checkout the hook actually fires from; without
+# this, a branch switch inside a brand-new, possibly-unreviewed worktree would
+# silently install that worktree's content into the real $HOME. Same for
+# `git clone -c core.hooksPath=hooks`, which persists the setting into a
+# fresh clone and fires on its first checkout. The receipt has to live
+# outside the repo (a clone would copy an in-repo marker along with it) and
+# outside .git/config (worktrees share that file), so ~/.local/state is the
+# only location that's both durable and tied to this $HOME rather than to any
+# one checkout. See hooks/_dispatch.sh for the guard that reads this back.
+log("Install receipt...")
+if DRY_RUN:
+    print(f"  would record install root: {DOTFILES}")
+else:
+    receipt = HOME / ".local" / "state" / "dotfiles" / "install-root"
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    receipt.write_text(f"{DOTFILES}\n", encoding="utf-8")
+    success(f"Recorded install root ({DOTFILES}) -> {receipt}")
+
 # ── shell ─────────────────────────────────────────────────────────────────────
 # Only these files are sourced into a running shell's environment at startup, so
 # only a change here means an already-open shell is stale. Everything else this

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ done
 
 self_update() {
   if [[ "$DRY_RUN" == "1" ]]; then
-    echo "  git -C $DOTFILES_DIR pull --ff-only origin" >&2
+    echo "  git -c fetch.pruneTags=false -C $DOTFILES_DIR pull --ff-only origin" >&2
     return 0
   fi
   skip() { echo "install.sh: skipping self-update — $1" >&2; }
@@ -59,7 +59,13 @@ self_update() {
   git -C "$DOTFILES_DIR" rev-parse --verify --quiet '@{upstream}' >/dev/null 2>&1 \
     || { skip "no upstream branch"; return 0; }
 
-  if DOTFILES_INSTALL_ACTIVE=1 git -C "$DOTFILES_DIR" pull --ff-only origin >/dev/null 2>&1; then
+  # fetch.pruneTags=false overrides the Captain's global fetch.pruneTags=true
+  # for this one pull: that global setting makes an ordinary --ff-only pull
+  # silently delete every local tag not on origin, even on a no-op
+  # "Already up to date" pull. fetch.prune (remote-tracking branches) is left
+  # alone — only tag deletion is destructive to state a pull has no business
+  # touching.
+  if DOTFILES_INSTALL_ACTIVE=1 git -c fetch.pruneTags=false -C "$DOTFILES_DIR" pull --ff-only origin >/dev/null 2>&1; then
     return 0
   fi
 


### PR DESCRIPTION
Fixes #23.

## Correction to the issue's stated mechanism

Issue #23 says `core.hooksPath = hooks` is "committed repo configuration, so it takes effect the moment a clone exists." **That is not accurate, and the repro in the issue does not reproduce.** Git never reads repo-tracked config. `core.hooksPath=hooks` lives only in `.git/config`, written imperatively by `install.py`. A fresh `git clone` — plain, `--local`, or `--shared` — gets no `hooksPath` and fires nothing.

The reported *impact* was entirely real, but the trigger was something else:

- **`git worktree add`, and branch switches inside a worktree.** Worktrees share the primary checkout's `.git/config`, so they inherit `core.hooksPath=hooks`; because `hooks` is a *relative* path, git resolves it inside whichever checkout the hook fires from. `worktree add` run from the primary installs the primary's content; a later `git checkout` run *inside* the worktree installs **that worktree's possibly-unreviewed content** into the real `$HOME`.
- **`git clone -c core.hooksPath=hooks <repo> <dir>`**, which git persists into the new clone's config and which fires on the clone's own initial checkout.

This matters for the fix: a guard aimed only at fresh clones would have missed the case that actually happens here. The `.claude/worktrees/agent-*` checkouts under this repo are wired exactly this way today.

## The fix: a canonical-install receipt

A deliberate install (`install.sh` / `install.ps1` → `install.py`) records the physically-resolved path of the checkout it installed from to `~/.local/state/dotfiles/install-root`. `hooks/_dispatch.sh` then no-ops unless that receipt exists **and** names this checkout.

- No receipt → no-op. A machine that has never had a deliberate install must never get one from an incidental git operation.
- Receipt naming a different checkout → no-op, with a one-line message naming both paths.
- Match → proceeds exactly as before.

The receipt has to live outside the repo (a clone would copy an in-repo marker) and outside `.git/config` (worktrees share that file), which makes `~/.local/state` the only location that is both durable and tied to this `$HOME` rather than to any one checkout.

**Why this approach over an opt-in env var:** a canonical-path check protects every future clone and worktree *by default, with zero action required from whoever created it*. An opt-in variable like `DOTFILES_ALLOW_INSTALL=1` only helps someone who already knows the danger exists — which is precisely the knowledge an unsuspecting cloner (or an agent making a scratch verification clone) doesn't have. The bar here is that an uninformed clone is safe.

**Why the guard is only on the hook-triggered path:** `install.sh`'s own header documents that VS Code clones this repo to an arbitrary path and runs it automatically to provision devcontainers. A blanket canonical-path refusal inside the installer would break that legitimate flow, so a deliberate `bash install.sh` still works from anywhere; only the *incidental*, hook-triggered path is gated.

## Second fix: `install.sh` no longer deletes local tags

`self_update()`'s `git pull --ff-only origin`, combined with the global `fetch.pruneTags = true`, silently deleted every local-only tag on **every** install — even a no-op "Already up to date" pull. Now scoped with `-c fetch.pruneTags=false` for that one pull. `fetch.prune` (remote-tracking branches) is deliberately left alone. Applied to `install.ps1` too, which duplicates the pull logic natively.

## Verification

Reproduced against throwaway `HOME` directories, never a real one.

| Check | Result |
| --- | --- |
| `worktree add` + in-worktree branch switch, pre-fix | Installer ran; symlinks landed in fake `$HOME`, repointing to the worktree on the second trigger |
| Same, post-fix | Single skip line; fake `$HOME` empty |
| `git clone -c core.hooksPath=hooks`, post-fix | No-op; fake `$HOME` empty |
| No receipt present | No-op |
| **Canonical checkout, receipt matching → branch switch** | **Installer still runs normally** (anti-over-blocking) |
| Deliberate `bash install.sh` from an arbitrary path | Completes, writes receipt, 31 symlinks created |
| Local-only tag across an install | Survives post-fix; deleted pre-fix (negative control) |
| Symlink planted at receipt path | Decoy file untouched post-fix; overwritten pre-fix (negative control) |
| Real `$HOME` after all experiments | 34 links, all still resolving to `/home/wsl/code/dotfiles`; zero pointing at scratch |

## Reviewer notes / known limitations

- **The Windows path-normalization is logic-verified only.** `_dotfiles_normalize_win_path()` reconciles Win32-form receipt paths (native Python: `C:\Users\...`) against MSYS-form hook paths (Git-for-Windows `sh`: `/c/Users/...`), which would otherwise never compare equal and would silently disable auto-sync on a native-Windows checkout forever. It was exercised via extracted-function unit tests and a mocked `cygpath` on this WSL-only machine — **never against real Git-for-Windows `sh`, real native-Windows Python, or a real `cygpath`.** Not claimed as end-to-end verified.
- The guard authenticates by **path string, not content or remote identity**. Replacing the canonical directory in place would pass it. That is a pre-existing trust boundary, not new here.
- This does not retroactively neutralize the currently-armed `agent-*` worktrees; they stop being hazardous once this lands and a deliberate install re-runs in the canonical checkout.
