### PR TITLE
fix: scrub hardcoded Windows username from published files

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ In every case tested the global guardrail hooks still fired and still blocked, i
 The Claude Code install that's actually kept current lives **inside WSL**. So
 that muscle memory still works from the Windows side, `powershell/profile.ps1`
 defines a `claude` **function** that starts a session inside Debian, in the
-translated working directory (`C:\Users\jerem\code\foo` →
-`/mnt/c/Users/jerem/code/foo`), with the exit code handed back to the caller.
+translated working directory (`C:\Users\you\code\foo` →
+`/mnt/c/Users/you/code/foo`), with the exit code handed back to the caller.
 
 **What's covered — and what isn't.** The function is the only forwarding
 mechanism, so it applies exactly where the profile is loaded:

--- a/hooks/_dispatch.sh
+++ b/hooks/_dispatch.sh
@@ -32,9 +32,9 @@ fi
 # of the receipt check come from different toolchains and render the *same*
 # physical directory two different ways:
 #   - install.py runs under native Windows Python and writes the Win32 form,
-#     e.g. C:\Users\jeremy\dotfiles
+#     e.g. C:\Users\you\dotfiles
 #   - this hook runs under Git-for-Windows' MSYS sh and computes DOTFILES_DIR
-#     with `pwd -P`, giving the POSIX/MSYS form, e.g. /c/Users/jeremy/dotfiles
+#     with `pwd -P`, giving the POSIX/MSYS form, e.g. /c/Users/you/dotfiles
 # A raw string compare of those two can never match, so the receipt guard
 # would fail closed forever on Windows -- safe, but it permanently disables
 # the sync this guard exists to allow. This function maps either form to one

--- a/ssh/config.local.example
+++ b/ssh/config.local.example
@@ -10,11 +10,11 @@
 # ── jump host pattern ─────────────────────────────────────────────────────────
 # Host *.internal
 #     ProxyJump   bastion.example.com
-#     User        jeremy
+#     User        you
 
 # ── example host ─────────────────────────────────────────────────────────────
 # Host myserver
 #     HostName    192.168.1.100
-#     User        jeremy
+#     User        you
 #     IdentityFile ~/.ssh/id_ed25519_myserver
 #     Port        22

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -134,12 +134,6 @@
   "dev.containers.mountWaylandSocket": false,
   "task.allowAutomaticTasks": "on",
 
-  // ── todo-tree ────────────────────────────────────────────────────────────────
-  // todo-tree calls fs.existsSync() directly on this value (no PATH search, no
-  // env-var expansion), so it must be a literal absolute path to the binary.
-  // This is winget's stable per-user shim for BurntSushi.ripgrep.MSVC (see
-  // packages/winget.txt) - not tied to a manually-installed package manager.
-  "todo-tree.ripgrep.ripgrep": "C:\\Users\\jerem\\AppData\\Local\\Microsoft\\WinGet\\Links\\rg.exe",
   "diffEditor.hideUnchangedRegions.enabled": true,
   "diffEditor.renderSideBySide": false,
 }


### PR DESCRIPTION
Closes #9.

## What

Replace the hardcoded Windows username (`jerem` / `jeremy`) with the neutral token `you` wherever it appears in published files, and drop one machine-specific VS Code setting.

| File | Change |
|---|---|
| `README.md` | `C:\Users\jerem\code\foo` / `/mnt/c/Users/jerem/code/foo` path example -> `...\you\...` |
| `hooks/_dispatch.sh` | two comment lines, `C:\Users\jeremy\dotfiles` / `/c/Users/jeremy/dotfiles` -> `...you...` (comment only, no code path touched) |
| `ssh/config.local.example` | two commented-out example lines, `User        jeremy` -> `User        you` |
| `vscode/settings.json` | remove `"todo-tree.ripgrep.ripgrep"` -- it pinned an absolute path under the same user profile. todo-tree `fs.existsSync()`s the value with no PATH search or env expansion, so there is no portable templated form; unset, it falls back to its bundled ripgrep (the right cross-platform default). Stale comment block removed with it. |

## Why forward-only (no history rewrite)

Issue #9 raised the option of rewriting history. Decided against it:

- The data is a Windows **username in path examples and comments**, not a credential. #9 itself flags it as advisory / functionally harmless.
- The repo's own identity is already `jmuise <jeremy.muise@gmail.com>` on every commit; the more-identifying `jeremymuise` form only ever existed in old historical blobs as a stale clone URL, never at HEAD.
- `main` is a protected branch; a rewrite means unprotect -> force-push -> re-protect, and it breaks every existing clone plus the `--ff-only` self-update in `install.{sh,ps1}` on derived checkouts.
- It would not even be complete: merged/closed PRs (#1, #2, #10, #28) keep the pre-rewrite commits reachable by SHA on github.com regardless -- PR #28's diff keeps showing the username. Only a GitHub Support request clears that.

## Verification

- `git grep -i jerem` / `jeremymuise` on the branch tip -> clean
- `bash -n hooks/_dispatch.sh` -> OK
- `vscode/settings.json` still parses as JSONC (whole-line `//` comments + trailing commas)
- The identical 4-file diff was security-reviewed (secrets / injection / regressions) -> PASS

## Follow-up (maintainer's call, not in this PR)

- `git push origin --delete fix/clone-time-install-hazard` -- merged PR #28's leftover branch still carries the username at `eb592a5`.
- Whether a GitHub Support request to expire cached closed-PR commit views is worth it (probably not, for a username in path examples).
