### PR TITLE
fix(install): gate credential writes on --dry-run and stop aborting on a symlinked receipt path

### DIFF
--- a/hooks/_dispatch.sh
+++ b/hooks/_dispatch.sh
@@ -61,6 +61,7 @@ _dotfiles_normalize_win_path() {
       # Win32 drive-letter form.
       if command -v cygpath >/dev/null 2>&1; then
         out=$(cygpath -u -- "$in" 2>/dev/null) || return 1
+        case "$out" in /*) ;; *) return 1;; esac
       else
         drive=$(printf '%s' "$in" | cut -c1 | tr '[:upper:]' '[:lower:]')
         rest=$(printf '%s' "$in" | cut -c3- | tr '\\' '/')

--- a/install.py
+++ b/install.py
@@ -233,16 +233,22 @@ elif not is_devcontainer() and not is_windows:
     # devcontainers can pull it via `git credential fill dotfiles-identity.local`.
     # Skipped on Windows — GCM handles devcontainer credential forwarding natively
     # and shows interactive dialogs for unrecognised hosts regardless of env flags.
-    git_credential_approve("https", IDENTITY_HOST, effective_name, effective_email)
+    if DRY_RUN:
+        print(f"  would write git identity to credential store: host={IDENTITY_HOST} username={effective_name}")
+    else:
+        git_credential_approve("https", IDENTITY_HOST, effective_name, effective_email)
 
 if not is_devcontainer() and not is_windows and shutil.which("gh"):
-    gh_token = run("gh", "auth", "token", timeout=10).stdout.strip()
-    if gh_token:
-        git_credential_approve("https", GH_HOST, "gh-cli", gh_token)
-        readback = git_credential_fill("https", GH_HOST, "gh-cli").get("password", "")
-        if readback != gh_token:
-            warn("gh token approve reported success but reading it back didn't match — likely not persisted. "
-                 "Run 'git config --get credential.helper' to check. See secrets/README.md.")
+    if DRY_RUN:
+        print(f"  would write gh OAuth token to credential store: host={GH_HOST} username=gh-cli (skipping 'gh auth token')")
+    else:
+        gh_token = run("gh", "auth", "token", timeout=10).stdout.strip()
+        if gh_token:
+            git_credential_approve("https", GH_HOST, "gh-cli", gh_token)
+            readback = git_credential_fill("https", GH_HOST, "gh-cli").get("password", "")
+            if readback != gh_token:
+                warn("gh token approve reported success but reading it back didn't match — likely not persisted. "
+                     "Run 'git config --get credential.helper' to check. See secrets/README.md.")
 
 # ── git hooks ─────────────────────────────────────────────────────────────────
 log("Git hooks...")
@@ -281,23 +287,48 @@ if DRY_RUN:
     print(f"  would record install root: {DOTFILES}")
 else:
     receipt = HOME / ".local" / "state" / "dotfiles" / "install-root"
-    receipt.parent.mkdir(parents=True, exist_ok=True)
     # Refuse to write through a symlink. write_text() opens with plain
     # open(..., "w"), which follows symlinks and truncates whatever they
-    # point at -- a symlink planted at the receipt path (or its immediate
-    # parent dir) before this runs would turn a routine install into an
-    # attacker-chosen arbitrary-file overwrite. Same awareness as
-    # write_through_symlink() above, applied in the opposite direction: that
-    # helper deliberately follows a symlink because a user's own dotfile
-    # symlinks are meant to be written through; this receipt has no
-    # legitimate reason to ever be a symlink, so we refuse instead.
-    if receipt.parent.is_symlink():
-        error(f"{receipt.parent} is a symlink — refusing to write install receipt through it")
-        sys.exit(1)
-    if receipt.is_symlink():
-        receipt.unlink()
-    receipt.write_text(f"{DOTFILES}\n", encoding="utf-8")
-    success(f"Recorded install root ({DOTFILES}) -> {receipt}")
+    # point at -- a symlink planted at the receipt path, at its immediate
+    # parent dir, or at ANY ancestor dir up to $HOME before this runs would
+    # turn a routine install into an attacker-chosen arbitrary-file
+    # overwrite. A symlinked ancestor is just as dangerous as a symlinked
+    # parent: receipt.parent.mkdir(parents=True) would happily create the
+    # rest of the tree *inside* the redirected location and the write would
+    # then land there undetected, so the check has to walk every component
+    # from receipt.parent up to (and including) HOME, and must run before
+    # the mkdir. Same awareness as write_through_symlink() above, applied in
+    # the opposite direction: that helper deliberately follows a symlink
+    # because a user's own dotfile symlinks are meant to be written through;
+    # this receipt has no legitimate reason to ever sit under one, so we
+    # refuse instead.
+    #
+    # A symlink anywhere on that path is a warn-and-skip, NOT an abort. The
+    # receipt only arms the git-hook auto-sync convenience (see
+    # hooks/_dispatch.sh); it is not load-bearing for the rest of this
+    # install -- shell, editors, CLIs, SSH, VS Code and global config all
+    # come afterward and must still run. Skipping the write leaves the guard
+    # disarmed, which is the safe direction, but the user has to be told.
+    symlinked_component = None
+    for _component in receipt.parents:
+        if _component.is_symlink():
+            symlinked_component = _component
+            break
+        if _component == HOME:
+            break
+    if symlinked_component is not None:
+        warn(f"{symlinked_component} is a symlink — NOT writing the install receipt "
+             f"through it (an ancestor symlink would redirect the write outside "
+             f"~/.local/state). The git-hook auto-sync guard stays DISARMED: "
+             f"hooks/_dispatch.sh will skip every hook-triggered install of this "
+             f"checkout until you remove the symlinked component and re-run "
+             f"'bash install.sh' by hand. The rest of this install continues.")
+    else:
+        receipt.parent.mkdir(parents=True, exist_ok=True)
+        if receipt.is_symlink():
+            receipt.unlink()
+        receipt.write_text(f"{DOTFILES}\n", encoding="utf-8")
+        success(f"Recorded install root ({DOTFILES}) -> {receipt}")
 
 # ── shell ─────────────────────────────────────────────────────────────────────
 # Only these files are sourced into a running shell's environment at startup, so


### PR DESCRIPTION
Closes #6
Closes #29

>**Scope note:** this PR touches machinery slated for removal in the provisioning split.
>The credential-seeding and receipt code fixed here is deleted in Phase 2 of that epic.
>The fix is still correct and worth landing now: it closes a live consent bug on the
>installer as it exists today, and Phase 2 is not yet cut.

Three consent-and-safety fixes in the installer, plus the hardening tail from #30.

**#30 is deliberately NOT closed by this PR.** It carries only the `cygpath` output-shape check below; the remaining question in #30 (verification against a real Git-for-Windows environment) is untouched and the wontfix decision there is still open.

## What changed

### `--dry-run` no longer writes to the credential store (#6)

`./install.sh --dry-run` was writing the git identity **and a live `gh` OAuth token** into the OS credential store. The two `git_credential_approve()` calls were gated on `not is_devcontainer() and not is_windows` but never on `DRY_RUN`, so a command whose entire contract is "make no changes" was persisting a real credential.

Both call sites are now gated. Under `DRY_RUN` the installer prints what it *would* write — host and username only — and skips the `gh auth token` subprocess entirely, so the token value is never even read into the process.

### Receipt write no longer follows a symlinked ancestor (#29.1)

The install receipt is written with `write_text()`, which follows symlinks and truncates whatever it lands on. The old check tested only `receipt.parent.is_symlink()`. A symlink one level higher — at `~/.local` or `~/.local/state` — was not checked, and `mkdir(parents=True)` would cheerfully build the rest of the tree *inside* the redirected location, after which the write proceeded undetected. That is an attacker-chosen arbitrary-file overwrite.

The check now walks every component from `receipt.parent` up to and including `HOME`, and runs *before* the `mkdir`. `HOME` itself is inspected before the walk stops, so a symlinked `$HOME` is caught too.

### A symlinked parent no longer aborts the whole install (#29.2)

Detecting that symlink used to `error()` and `sys.exit(1)`, killing the installer before shell, editors, CLIs, SSH, VS Code and global config had run. The receipt only arms the git-hook auto-sync convenience in `hooks/_dispatch.sh`; it is not load-bearing for anything after it. Aborting was a denial-of-install that bought no security — an attacker able to plant that symlink already has write access to the home tree.

It is now a `warn()` that skips only the receipt write. The warning states that the auto-sync guard stays **DISARMED**, names the file responsible, and says how to re-arm it. Skipping the write is the fail-safe direction.

### `cygpath` exit code is no longer trusted alone (#30 tail)

`hooks/_dispatch.sh`, `_dotfiles_normalize_win_path`: `out=$(cygpath -u -- "$in" 2>/dev/null) || return 1` trusted the exit code without checking the shape of stdout. A `cygpath` that exits 0 while emitting an empty string, an error message, or a relative path would have its output used as a path. Now gated on the result being absolute.

## Verification

**`--dry-run` performs no credential write.** Run with a transparent PATH shim in front of the real `git`/`gh` that logs and passes through any `git credential approve` or `gh auth token` call:

```
$ wc -l < /tmp/credshim/calls.log
0
```

The shim's own detection was self-tested first — benign calls not logged, `credential approve` and `gh auth token` both logged, 2/2 — so an empty log is evidence the calls did not happen, not evidence the shim was broken. `git credential fill` for both synthetic hosts was identical before and after (corroborating only; the store already held entries from prior real installs).

The dry run completes end to end, exit 0, printing host and username with no token value:

```
would write git identity to credential store: host=dotfiles-identity.local username=<name>
would write gh OAuth token to credential store: host=dotfiles-gh.local username=gh-cli (skipping 'gh auth token')
```

**Receipt ancestor walk.** A harness extracts the guard block verbatim from `install.py` and executes it against constructed temp trees, planting a canary file at the redirect target and asserting it is never created. No real install was run on this machine.

```
symlinked_immediate_parent  -> warn, no exit, canary not written  PASS
symlinked_mid_ancestor      -> warn, no exit, canary not written  PASS
symlinked_top_ancestor      -> warn, no exit, canary not written  PASS
clean_control               -> receipt written normally           PASS
symlink_above_home_ignored  -> receipt written, walk stopped      PASS
```

**`cygpath` shape guard**, function sourced with a stubbed `cygpath`:

```
PASS  absolute path              accepted
PASS  exit 0, relative stdout    rejected
PASS  exit 0, empty stdout       rejected
PASS  exit 0, Win32 path stdout  rejected
PASS  nonzero exit               rejected
PASS  already-posix, no cygpath  accepted
```

`python3 -m py_compile install.py` and `bash -n hooks/_dispatch.sh` both pass. Non-dry-run behaviour is unchanged apart from the sanctioned receipt downgrade: both credential blocks wrap the original code byte-identically in an `else`.

## Review

Independent security review completed before push. Verdict APPROVE, no blocking findings. Two advisory items were raised and are deliberately not addressed here:

- The symlinked-ancestor case could additionally force a non-zero exit at end of script so non-interactive callers notice the disarmed guard.
- A TOCTOU window exists between the symlink walk and `write_text`. It is unchanged from the pre-fix code and requires an attacker who already holds write access to the home tree.

