### PR TITLE
fix(devcontainer-guard): fail closed on git failure, oversized commands, and pinned hook timeouts

### DIFF
--- a/claude/hooks/require-devcontainer.sh
+++ b/claude/hooks/require-devcontainer.sh
@@ -113,6 +113,29 @@ block() {
   exit 2
 }
 
+# Am I in *some* container? Any one signal is sufficient. This intentionally
+# does not try to prove it is *this project's* container -- the failure being
+# guarded against is work landing on the bare host.
+#
+# This runs BEFORE the git probe below on purpose. in_container reads only
+# /.dockerenv, /proc/1/cgroup and two env vars -- nothing the git probe
+# produces -- so moving it up introduces no bypass, and taking the container
+# escape first means a benign git failure cannot deny every Bash/Edit/Write
+# *inside a container*, where there is no host to protect. The common trigger
+# is not theoretical: on a Linux devcontainer with a bind-mounted workspace
+# the container uid routinely differs from the host uid, so git emits
+# `fatal: detected dubious ownership...` for every command until safe.directory
+# is set. The .no-auto-provision marker check stays BELOW the probe because it
+# needs $project_root.
+in_container() {
+  [ -f /.dockerenv ] && return 0
+  [ -r /proc/1/cgroup ] && grep -qE '(docker|containerd)' /proc/1/cgroup && return 0
+  [ "${REMOTE_CONTAINERS:-}" = "true" ] && return 0
+  [ -n "${CODESPACES:-}" ] && return 0
+  return 1
+}
+in_container && exit 0
+
 # Which repo, if any, owns this target? Issue #3: a git *failure* here used to be
 # indistinguishable from "not a git repo". The old line was
 #   project_root=$(git ... rev-parse --show-toplevel 2>/dev/null) || exit 0
@@ -124,11 +147,25 @@ block() {
 #
 # One git invocation still, same as before -- `2>&1` keeps stderr so the failure
 # can be classified instead of thrown away. On success stdout is the path and
-# stderr is empty, so the merged capture is clean. block() is defined just above
-# (moved up from its old spot below in_container) so this path can reach it;
-# project_root is reset to "" before any block() call because block() interpolates
-# $project_root under `set -u` and would otherwise trip the ERR trap with a
-# misleading "guard itself failed" message.
+# stderr is empty, so the merged capture is clean. block() and in_container are
+# both defined just above, so this path can reach block() and the container
+# escape has already been taken; project_root is reset to "" before any block()
+# call because block() interpolates $project_root under `set -u` and would
+# otherwise trip the ERR trap with a misleading "guard itself failed" message.
+#
+# The classification matches git's fatal messages as PREFIXES, not substrings.
+# git echoes repo paths and config values verbatim into its fatal text, so that
+# text is attacker-influenceable: a guarded repo whose .git/config carries
+#   [core]
+#       bare = not a git repository
+# makes git die with
+#   fatal: bad boolean config value 'not a git repository' for 'core.bare'
+# and an unanchored *"not a git repository"* match would read that as
+# out-of-scope and ALLOW every command against the repo. The genuine messages
+# are `fatal: not a git repository...` and `fatal: this operation must be run in
+# a work tree`; `export LC_ALL=C` above pins git to English so those exact
+# leading forms are reliable. Anything that only CONTAINS the phrase further
+# along the line is a crafted message and must fall through to the default deny.
 project_root=""
 if project_root=$(git -C "$target" rev-parse --show-toplevel 2>&1); then
   :   # success: project_root holds the work-tree root
@@ -136,8 +173,8 @@ else
   git_err=$project_root
   project_root=""
   case "$git_err" in
-  *"not a git repository"*) exit 0 ;;          # genuinely not a repo -- out of scope
-  *"must be run in a work tree"* | *"this operation must be run in a work tree"*)
+  "fatal: not a git repository"*) exit 0 ;;    # genuinely not a repo -- out of scope
+  "fatal: this operation must be run in a work tree"*)
     exit 0 ;;                                  # bare repo / no work tree -- out of scope, as before
   *)
     block "could not determine the git repository state of \"$target\" -- git failed with: ${git_err:-<no output>}. The guard is refusing this call rather than assuming the path is unguarded. Fix the underlying git problem (git missing from PATH, dubious ownership, a locked or corrupt repo) or relaunch inside the container."
@@ -154,17 +191,8 @@ fi
 # for the marker and never for a hardcoded path -- the marker is the mechanism.
 [ -f "$project_root/.no-auto-provision" ] && exit 0
 
-# Am I in *some* container? Any one signal is sufficient. This intentionally
-# does not try to prove it is *this project's* container -- the failure being
-# guarded against is work landing on the bare host.
-in_container() {
-  [ -f /.dockerenv ] && return 0
-  [ -r /proc/1/cgroup ] && grep -qE '(docker|containerd)' /proc/1/cgroup && return 0
-  [ "${REMOTE_CONTAINERS:-}" = "true" ] && return 0
-  [ -n "${CODESPACES:-}" ] && return 0
-  return 1
-}
-in_container && exit 0
+# (in_container is defined and consulted above, before the git probe, so a
+# benign git failure cannot deny work that is already safely containerized.)
 
 # Mutating a project file from the bare host has no legitimate form once this
 # rule exists, so there is nothing to allowlist here.
@@ -247,7 +275,20 @@ while IFS= read -r segment; do
 
   find)
     # find is a read tool until it isn't: -exec/-delete make it arbitrary.
-    if printf '%s' "$segment" | grep -qE '(^|[[:space:]])-(exec|execdir|ok|okdir|delete|fprint|fprintf|fls)([[:space:]]|$)'; then
+    # Bash-native `[[ =~ ]]`, NOT `printf ... | grep`: a subprocess in this arm
+    # runs once PER SEGMENT -- roughly 1000x the cost of the allowlist arms --
+    # and a single Bash call chaining thousands of `find` segments while still
+    # under the 64 KiB ceiling could burn the entire 30s pinned hook budget on
+    # fork/exec before the loop ever reaches a dangerous tail segment. A
+    # timed-out PreToolUse hook does NOT block, so that is a fail-open, and the
+    # ceiling does not bound it. `[[ =~ ]]` forks nothing. The pattern is held
+    # in a variable and the RHS left UNQUOTED so it is parsed as an ERE (a
+    # quoted RHS matches literally and would silently neuter the check); it is
+    # byte-for-byte the same ERE, character classes included, that `grep -E`
+    # used. As the condition of an `if` a non-match does not trip `set -e` /
+    # the ERR trap. It clobbers BASH_REMATCH, which nothing here reads.
+    find_mutating_re='(^|[[:space:]])-(exec|execdir|ok|okdir|delete|fprint|fprintf|fls)([[:space:]]|$)'
+    if [[ $segment =~ $find_mutating_re ]]; then
       block "find with -exec/-delete can mutate the tree"
     fi
     ;;

--- a/claude/hooks/require-devcontainer.sh
+++ b/claude/hooks/require-devcontainer.sh
@@ -37,8 +37,10 @@
 # at the newline *regardless* of a trailing backslash, so `ls -la #\` + newline
 # + `bash evil.sh` spliced into one segment headed by an allowlisted `ls` and
 # ran arbitrary code against a guarded working tree. The splice was also
-# quadratic in line count -- ~176s on 32k lines, past Claude Code's 60s default
-# hook timeout, and a timed-out hook does not exit 2, so the tool call proceeds.
+# quadratic in line count -- ~176s on 32k lines, past the PreToolUse hook
+# timeout (600s by default in Claude Code, pinned to 30s for this hook in
+# claude/settings.json), and a timed-out hook does not exit 2, so the tool call
+# proceeds.
 # An ACE bypass and a fail-open, bought for the convenience of not retyping a
 # command on one line. Modelling shell quoting and comments does not belong in a
 # security guard; when a continuation is refused, join the lines. The over-block
@@ -59,6 +61,15 @@ set -Eeuo pipefail
 # trap from inside it does not help (the subshell only disarms its own copy),
 # and the exit code is 2 either way, so the duplication is left alone.
 trap 'echo "BLOCKED by claude/hooks/require-devcontainer.sh: the guard itself failed unexpectedly near line $LINENO, so this call is refused rather than silently allowed. This is a bug in the hook, not in your command -- report it to the Captain." >&2; exit 2' ERR
+
+# Pin the C locale, exactly as copilot/hooks/require-devcontainer.sh does and for
+# the same reason: the command-size ceiling below is enforced with `${#command}`,
+# and under a UTF-8 locale that counts CHARACTERS, so an all-multibyte command
+# could carry several times the byte budget the check reports and undercount its
+# way past the ceiling into the super-linear segment loop. In the C locale
+# `${#command}` is a true byte count. It also makes grep/sed treat the command as
+# opaque bytes rather than possibly refusing invalid UTF-8.
+export LC_ALL=C
 
 input=$(cat)
 tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty')
@@ -93,8 +104,49 @@ while [ ! -d "$target" ] && [ "$target" != "/" ] && [ -n "$target" ]; do
   target=$(dirname -- "$target")
 done
 
-# Not inside a git repo at all (scratch dir, $HOME, /tmp) -- out of scope.
-project_root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) || exit 0
+block() {
+  echo "BLOCKED by claude/hooks/require-devcontainer.sh: $1" >&2
+  # agent_type (parsed above, hardcoded as "kilo"/"copilot" by those shims) is
+  # available here if a future tool-specific message is ever wanted -- that
+  # would be a `case "$agent_type"` in this function, not an interface change.
+  echo "This session is not running inside the devcontainer for the project at $project_root, so it may not edit its files or run project commands against it. Getting containerized means relaunching the session inside the container; no worker can arrange that for itself mid-task, and host-side work is never the substitute. If the project has no .devcontainer/ yet, retrofitting one needs the Captain's confirmation first; if it has one and this session simply isn't in it, the session needs relaunching inside it. Route that through whatever provisioning path this CLI has -- and if it has none, stop and tell the Captain rather than working around it. The \`devcontainer-first\` skill holds the full decision tree. (Agent: \"$agent_type\")" >&2
+  exit 2
+}
+
+# Which repo, if any, owns this target? Issue #3: a git *failure* here used to be
+# indistinguishable from "not a git repo". The old line was
+#   project_root=$(git ... rev-parse --show-toplevel 2>/dev/null) || exit 0
+# so git missing from PATH (127), dubious-ownership (128), a locked or corrupt
+# repo (128) -- every one of them -- discarded stderr and fell through to a
+# silent ALLOW. Only a genuine "not a git repository" (and the bare-repo
+# "must be run in a work tree", which the old code also allowed) is out of scope;
+# any OTHER git failure leaves repo state UNKNOWN, and unknown state must DENY.
+#
+# One git invocation still, same as before -- `2>&1` keeps stderr so the failure
+# can be classified instead of thrown away. On success stdout is the path and
+# stderr is empty, so the merged capture is clean. block() is defined just above
+# (moved up from its old spot below in_container) so this path can reach it;
+# project_root is reset to "" before any block() call because block() interpolates
+# $project_root under `set -u` and would otherwise trip the ERR trap with a
+# misleading "guard itself failed" message.
+project_root=""
+if project_root=$(git -C "$target" rev-parse --show-toplevel 2>&1); then
+  :   # success: project_root holds the work-tree root
+else
+  git_err=$project_root
+  project_root=""
+  case "$git_err" in
+  *"not a git repository"*) exit 0 ;;          # genuinely not a repo -- out of scope
+  *"must be run in a work tree"* | *"this operation must be run in a work tree"*)
+    exit 0 ;;                                  # bare repo / no work tree -- out of scope, as before
+  *)
+    block "could not determine the git repository state of \"$target\" -- git failed with: ${git_err:-<no output>}. The guard is refusing this call rather than assuming the path is unguarded. Fix the underlying git problem (git missing from PATH, dubious ownership, a locked or corrupt repo) or relaunch inside the container."
+    ;;
+  esac
+fi
+
+# Belt-and-braces for the racy case where the tree vanishes after a clean
+# rev-parse: an empty root is treated as genuinely-not-a-repo, exactly as before.
 [ -n "$project_root" ] || exit 0
 
 # The portable opt-out: a repo whose job is configuring the host it lives on
@@ -114,15 +166,6 @@ in_container() {
 }
 in_container && exit 0
 
-block() {
-  echo "BLOCKED by claude/hooks/require-devcontainer.sh: $1" >&2
-  # agent_type (parsed above, hardcoded as "kilo"/"copilot" by those shims) is
-  # available here if a future tool-specific message is ever wanted -- that
-  # would be a `case "$agent_type"` in this function, not an interface change.
-  echo "This session is not running inside the devcontainer for the project at $project_root, so it may not edit its files or run project commands against it. Getting containerized means relaunching the session inside the container; no worker can arrange that for itself mid-task, and host-side work is never the substitute. If the project has no .devcontainer/ yet, retrofitting one needs the Captain's confirmation first; if it has one and this session simply isn't in it, the session needs relaunching inside it. Route that through whatever provisioning path this CLI has -- and if it has none, stop and tell the Captain rather than working around it. The \`devcontainer-first\` skill holds the full decision tree. (Agent: \"$agent_type\")" >&2
-  exit 2
-}
-
 # Mutating a project file from the bare host has no legitimate form once this
 # rule exists, so there is nothing to allowlist here.
 if [ "$tool_name" != "Bash" ]; then
@@ -131,6 +174,21 @@ fi
 
 command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
 [ -n "$command" ] || exit 0
+
+# Issue #4: the segment loop further down is super-linear (~n^1.4) in the length
+# of the command and carries no deadline of its own. A PreToolUse hook that times
+# out does NOT block -- Claude Code lets the call proceed -- so a command long
+# enough to blow the hook timeout is a silent fail-open. Cap the input at a size
+# the loop chews through in a small fraction of a second, far inside the 30s this
+# hook is pinned to in claude/settings.json, so the ceiling is always the thing
+# that trips first and the timeout is never reached. ${#command} is a BYTE count
+# here only because of the `export LC_ALL=C` at the top of this file; under a
+# UTF-8 locale it would count characters and a multibyte command could undercount
+# its way past the ceiling. Mirrors MAX_PAYLOAD_BYTES in
+# copilot/hooks/require-devcontainer.sh.
+if [ "${#command}" -gt 65536 ]; then
+  block "the Bash command is ${#command} bytes, over the 65536-byte (64 KB) ceiling this guard will inspect on the host. A command that large risks running the guard past its hook timeout, and a timed-out hook does not block -- so it is refused here instead. Split it into smaller commands, or run it inside the container."
+fi
 
 # Fold newlines to spaces for the two text passes below, exactly as
 # block-pr-merge.sh does and for the same reason: grep is line-oriented, so a real

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -26,7 +26,8 @@
           },
           {
             "type": "command",
-            "command": "bash \"$HOME/.claude/hooks/require-devcontainer.sh\""
+            "command": "bash \"$HOME/.claude/hooks/require-devcontainer.sh\"",
+            "timeout": 30
           }
         ]
       },
@@ -35,7 +36,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$HOME/.claude/hooks/require-devcontainer.sh\""
+            "command": "bash \"$HOME/.claude/hooks/require-devcontainer.sh\"",
+            "timeout": 30
           }
         ]
       },
@@ -44,7 +46,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$HOME/.claude/hooks/require-devcontainer.sh\""
+            "command": "bash \"$HOME/.claude/hooks/require-devcontainer.sh\"",
+            "timeout": 30
           }
         ]
       },
@@ -53,7 +56,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$HOME/.claude/hooks/require-devcontainer.sh\""
+            "command": "bash \"$HOME/.claude/hooks/require-devcontainer.sh\"",
+            "timeout": 30
           }
         ]
       }


### PR DESCRIPTION
Closes #3
Closes #4
Closes #7

Three fail-open paths in the devcontainer guard, closed together because they interact: the size ceiling from #4 and the pinned timeout from #7 are only safe as a pair, and getting that pairing wrong is itself an exploit.

## What changed

### Git failure is no longer indistinguishable from "not a repo" (#3)

`project_root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) || exit 0` discarded stderr, so exit 127 (git absent from PATH), exit 128 (dubious ownership, corrupt config, locked repo) and a genuine not-a-repo all collapsed into one silent ALLOW. An unknown repository state was being treated as an unguarded one.

Stderr is now captured and classified. Only the genuine not-a-repo and bare-repo messages allow; every other git failure blocks. Unknown state denies.

### A command too large to inspect is refused rather than raced (#4)

The Bash allowlist segment loop is super-linear with no input cap. Enough command text ran the hook past its timeout, and a timed-out `PreToolUse` hook does not block — the call proceeds. A 64 KiB ceiling now refuses oversized commands outright, counted in **bytes** (`LC_ALL=C`), so a multibyte payload cannot undercount its way past.

### Hook timeouts pinned (#7)

`"timeout": 30` on each of the four `require-devcontainer.sh` entries. This matters more than it looks: the field is in seconds, the real default is **600s** (not the 60s this file's comments previously claimed — corrected here), and timeouts are **fail-open**. The official documentation is explicit: *"a timed-out command, http, or mcp_tool hook doesn't block the tool call... don't count on a stalled hook to act as a gate."*

## The interaction that made review essential

Pinning 30s **narrows** the window in which #4's fail-open is reachable. It is only safe if the ceiling guarantees every inspectable command finishes well inside 30s.

The first implementation measured that margin using `ls;ls;ls…` — the cheap allowlist path — and reported ~2.1s at the ceiling, a comfortable 14x. Independent security review found the measurement was on the wrong path. The `find)` arm forked a subprocess **per segment**:

| payload just under the 64 KiB ceiling | segments | elapsed |
|---|---|---|
| `ls;ls;…` (what was measured) | 21,844 | ~2.6s |
| `find .\|find .\|…` (what was not) | 9,360 | **30.5s** |

A single `find .|find .|…(~9000x)…|npm ci` call at ~63 KB passed the ceiling, consumed the entire 30s budget in the fork loop, was killed before reaching the `npm ci` segment, and the call proceeded against the bare host. The 30s pin is what converted a latent slowness into a live bypass — at the 600s default the same payload blocks correctly.

Fixed by de-forking the arm to a bash-native `[[ $segment =~ $re ]]` (pattern in a variable, RHS unquoted so it parses as an ERE). Every other `case` arm was audited for the same pattern; `find)` was the only one. No arm now forks per segment.

| FIND path, after | segments | exit | wall |
|---|---|---|---|
| find, 16 KiB | 2,339 | 2 | 0.49s |
| find, 64 KiB (at ceiling) | 9,361 | 2 | 1.81s |
| single 65 KB find segment (regex stress) | 1 | — | 0.34s |
| **allowlist `ls;`, at ceiling (absolute worst case)** | 21,845 | — | **2.68s** |
| just over ceiling | — | 2 | 0.06s |

Worst case ~2.7s against a 30s pin — under 10% of budget. The find path is now cheaper than the allowlist path it was originally benchmarked against. The single-large-segment row confirms no ReDoS: the ERE has no nested quantifiers.

These are the reviewer's own measurements, not the author's. The same reviewer reproduced the pre-fix behaviour on the identical payload at **30.54s** — over the pin — confirming the fail-open was real rather than theoretical.

## Second finding: the stderr classification was defeatable

Review also found the #3 fix matched git's stderr as a bare substring. Git echoes config values and repository paths verbatim into fatal messages, so that text is attacker-influenceable. A `.git/config` containing

```
[core]
    bare = not a git repository
```

produces `fatal: bad boolean config value 'not a git repository' for 'core.bare'`, which matched the allow pattern. Running `npm ci` against that guarded repo through the hook was **observed exiting 0** — the fail-closed fix failing open.

Patterns are now anchored as prefixes rather than substrings. `LC_ALL=C` pins git's output to English, so the exact leading forms are reliable.

| case | before | after |
|---|---|---|
| crafted `.git/config` value | 0 (allowed) | **2 (block)** |
| directory named `not a git repository` inside a guarded repo | — | **2 (block)** |
| plain `/tmp` dir, `$HOME`, non-existent path over non-repo ancestor | — | 0 (allow) |
| genuine bare repo | — | 0 (allow) |

## Third: container blast radius

The git probe ran before the container check, so after the #3 change a benign git failure denied every Bash/Edit/Write **inside a container** and in marker-exempt repos, including this one. That trigger is routine rather than exotic: a bind-mounted devcontainer whose uid differs from the host's emits `fatal: detected dubious ownership` on every git call until `safe.directory` is set.

`in_container` and its early exit now precede the git probe. It reads only `/.dockerenv`, `/proc/1/cgroup`, `REMOTE_CONTAINERS` and `CODESPACES` — nothing the probe produces — so the reorder introduces no bypass. Host-side git failures in a guarded repo still block, for both Bash and Edit.

## Verification

Full matrix of 47 cases re-run after remediation, since the earlier run was invalidated by these edits.

Still blocking: command substitution (`$()`, backtick, `<()`), newline-separator smuggling (`$'ls\nnpm ci'`), `&&`/`;`/`|` tails, flag interposition (`git -C . push`, `git -c a.b=c push`), `find -exec`/`-delete`/`-execdir` mid-chain, `git branch`/`remote add`/`worktree add`, output redirection, `FOO=bar npm ci`, `/usr/bin/npm ci`, Edit/Write/NotebookEdit against a guarded repo, oversized commands, and both git-failure classes on the host.

Still allowing: container signals, the `.no-auto-provision` marker, genuine non-repo directories, genuine bare repos, the `chief-engineer` exemption, and the documented read-only allowlist including unicode arguments.

Command-substitution and redirection detection still block unicode-wrapped and raw invalid-UTF-8 payloads under `LC_ALL=C`.

`bash -n` clean, `jq .` valid, and the repo's `hooks/pre-commit` spine drift guard exits 0.

## Deliberately not addressed

Two behaviours were confirmed during verification and left alone, because changing either is a design decision outside these three issues:

- **`git status` and bare `ls` are allowed on the host in a non-exempt repo.** This is the guard's documented, deliberate narrow read-only allowlist (header lines 20-32). Blocking them would *narrow* the allowlist.
- **Tool-name matching is exact-case**, so `"bash"` would exit 0. Unchanged by this PR and not a regression. It is defensible because `settings.json`'s matchers gate invocation, but it is inconsistent with `33177ba`, which made the Copilot/Kilo shims deny-by-default on unknown tool names. Worth filing separately.

## Review

Two independent security reviews. The first returned CHANGES REQUESTED with the two blocking findings above; the second re-verified the remediation with its own measurements rather than the author's. The reviewed commit `c90df1d` was deliberately left unamended so the remediation is auditable as a separate commit.
