### PR TITLE
ci: bootstrap CI workflow (syntax + agent-spine drift + shellcheck)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: shell-python-syntax
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: python -m py_compile install.py
         run: python3 -m py_compile install.py
@@ -55,7 +55,7 @@ jobs:
     name: agent-spine-drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: hooks/pre-commit (spine drift + never-merge invariant)
         run: bash hooks/pre-commit
@@ -69,7 +69,7 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: shellcheck --severity=warning (operational core)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: hooks/pre-commit (spine drift + never-merge invariant)
-        run: bash hooks/pre-commit
+        run: |
+          bash hooks/pre-commit
+          echo "hooks/pre-commit passed: spine consistent, never-merge invariant intact"
 
   # Lint gate, scoped to the operational core: the installer entrypoint, the
   # git-hook machinery, the tools/ scripts, and the Claude hook scripts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Syntax-only gate: no interpreter runs the code, it is only parsed.
+  # Covers the Python installer core and every tracked shell script,
+  # including the extensionless git hooks.
+  shell-python-syntax:
+    name: shell-python-syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: python -m py_compile install.py
+        run: python3 -m py_compile install.py
+
+      - name: bash -n on every tracked shell script
+        run: |
+          set -uo pipefail
+          status=0
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            if bash -n "$f"; then
+              echo "ok    $f"
+            else
+              echo "FAIL  $f"
+              status=1
+            fi
+          done < <(
+            git ls-files \
+              '*.sh' \
+              'hooks/pre-commit' \
+              'hooks/post-checkout' \
+              'hooks/post-merge' \
+              'hooks/post-rewrite'
+          )
+          exit "$status"
+
+  # Invariant gate: runs the "number-one" agent-spine drift guard and the
+  # ABSOLUTE RULE (never-merge) invariant check. hooks/pre-commit reads the
+  # git index via `git show :<path>`, which on a fresh checkout is identical
+  # to HEAD, so the hook runs unmodified here with no staging step.
+  agent-spine-drift:
+    name: agent-spine-drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: hooks/pre-commit (spine drift + never-merge invariant)
+        run: bash hooks/pre-commit
+
+  # Lint gate, scoped to the operational core: the installer entrypoint, the
+  # git-hook machinery, the tools/ scripts, and the Claude hook scripts.
+  # severity=warning so style-only info notes do not gate merges. The rc
+  # fragments under shell/ and the platform helpers under git/, wsl/, macos/
+  # and secrets/ are deliberately out of scope here (see PR description).
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: shellcheck --severity=warning (operational core)
+        run: |
+          shellcheck --version
+          shellcheck --severity=warning --external-sources \
+            install.sh \
+            hooks/pre-commit \
+            hooks/_dispatch.sh \
+            tools/smart-editor.sh \
+            tools/start-project.sh \
+            tools/sync-agent.sh \
+            claude/hooks/block-ai-attribution.sh \
+            claude/hooks/block-pr-merge.sh \
+            claude/hooks/require-devcontainer.sh


### PR DESCRIPTION
## What

Adds `.github/workflows/ci.yml` — the first CI in this repo. Until now there
were no workflows and every PR reported "no checks reported". This is a
blocking prerequisite for a later phase of the provisioning-split epic
(which replaces the `hooks/pre-commit` drift guard + `tools/sync-agent.sh`
with a `make roster` step plus a CI `git diff --exit-code` check) and for
turning on branch protection with required status checks.

The change is purely additive: one workflow file, nothing else touched.

## Jobs

| Job name | What it runs |
| --- | --- |
| `shell-python-syntax` | `python3 -m py_compile install.py`; `bash -n` over every tracked shell script (all `*.sh` plus the extensionless `hooks/pre-commit`, `hooks/post-checkout`, `hooks/post-merge`, `hooks/post-rewrite`) |
| `agent-spine-drift` | `hooks/pre-commit` unmodified — the number-one agent-spine drift guard and the ABSOLUTE RULE never-merge invariant check |
| `shellcheck` | `shellcheck --severity=warning` scoped to the operational core: `install.sh`, `hooks/pre-commit`, `hooks/_dispatch.sh`, `tools/*.sh`, `claude/hooks/*.sh` |

Job names are chosen to be stable — they become the required status check
names in branch protection, so renaming them later silently breaks the
protection rule.

Triggers: `pull_request` (any base) and `push` to `main`. Runtime deps are
only `python3`, `bash` and `shellcheck`, all preinstalled on `ubuntu-latest`.

### `hooks/pre-commit` in CI

The drift guard reads staged content via `git show :<path>`. On a fresh
`actions/checkout` the index is identical to `HEAD`, so the hook runs
as-is with no staging step and no extraction of its logic into a separate
script. Verified locally against a clean checkout: exit 0.

## Deliberately out of scope

- **`shellcheck` over the whole repo.** The rc fragments under `shell/`
  and the platform helpers under `git/`, `wsl/`, `macos/`, `secrets/` have
  pre-existing shellcheck findings (see below). Fixing lint across the repo
  would balloon this PR; per the task brief it is left for a separate issue.
- **Branch protection is NOT enabled here.** That is a human action,
  sequenced after some pending PRs merge.
- No changes to `install.py`, `install.ps1`, `install.sh`,
  `hooks/pre-commit`, `tools/sync-agent.sh`, or anything under `claude/`.

## Pre-existing shellcheck findings (not fixed here — follow-up issue)

`bash -n` is clean across the entire repo. `shellcheck` (default severity)
is not, outside the operational core:

- `shell/aliases.sh`: SC2148 (no shebang, error), SC2142 (alias with `$1`, error), SC2262/SC2263
- `shell/doctor.sh`, `shell/exports.sh`, `shell/self-heal.sh`: SC2148 (no shebang, error)
- `git/ensure-gcm.sh`, `wsl/bridge-gcm.sh`: SC2088 (tilde in quotes, warning)
- info-level only (masked by `--severity=warning`, present even inside the operational core): `hooks/_dispatch.sh` SC1003, `hooks/pre-commit` SC2016, `tools/start-project.sh` SC2016, `claude/hooks/require-devcontainer.sh` SC2020

## Verification

Local (host bash 5.2, shellcheck 0.11.0):

- `python3 -m py_compile install.py` -> exit 0
- `bash -n` loop over all 26 tracked shell scripts/hooks -> all `ok`, exit 0
- `bash hooks/pre-commit` on a clean checkout -> exit 0
- `shellcheck --severity=warning` on the scoped file list -> clean, exit 0
- `ci.yml` parsed with a YAML loader -> valid; 3 jobs, names as above

CI result on this PR is recorded in the thread / `gh pr checks` once the
run completes.