### PR TITLE
feat(profile): define the profile file contract and a shared reader

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,187 @@
+# The `profile` file contract
+
+This directory defines **one** thing: the format and meaning of the file
+
+```
+${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/profile
+```
+
+and ships a small reader for it that every consumer shares. It does **not**
+wire any consumer up — the shell gate, the Python linker, the nvim
+`copilot.lua` gate and the `dotfiles profile <name>` CLI are all separate,
+later tasks. This is the contract and the parser, nothing downstream.
+
+## Why this file exists
+
+A dotfiles checkout can be switched into one of three **strictly nested**
+capability profiles, so a machine that contributes to projects with a no-AI
+contribution policy can be put into a state where no AI tooling is configured
+at all:
+
+| Profile   | What it means                                                                                                                                                    |
+|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `bare`    | Shell, git, nvim (**without** `copilot.lua`), tmux, starship, yazi, lazygit, editors, macros. No AI config directories, no AI npm globals.                          |
+| `inline`  | `bare` **plus** editor completion plugins (`copilot.lua`, VS Code inline suggestions) and the one-shot `claude` / `copilot` CLIs. No agent roster, no `~/.claude/agents`, no skills, no MCP, no orchestrator. |
+| `agentic` | Everything the repo ships today. The full agent roster, skills, hooks, MCP, orchestrator.                                                                          |
+
+The nesting is a subset relation on *capabilities*:
+
+```
+bare  ⊂  inline  ⊂  agentic
+```
+
+Anything enabled at `bare` is enabled at `inline` and `agentic`; anything
+enabled at `inline` is also enabled at `agentic`. A consumer therefore never
+switches on the exact profile string — it asks "is my capability's minimum
+level satisfied?" and compares by rank:
+
+| Profile   | Rank |
+|-----------|------|
+| `bare`    | 0    |
+| `inline`  | 1    |
+| `agentic` | 2    |
+
+"Capability X needs at least `inline`" is `rank(active) >= rank(inline)`.
+
+## The contract
+
+The file holds **exactly one profile name** and nothing else. It is the
+single source of truth, read by three independent consumers (the shell, the
+Python linker, Ansible). The rules below are deliberately strict so those
+three can never drift apart on an edge case.
+
+### Resolution rules
+
+Given the file at `${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/profile`
+(with `XDG_CONFIG_HOME` treated as unset when it is empty):
+
+| # | Situation | Result |
+|---|-----------|--------|
+| 1 | **File absent** (no such path, and not a broken symlink) | Resolve to **`agentic`**. This is the *only* implicit default. It preserves today's behaviour for every checkout that predates this feature. |
+| 2 | **File present, contents are exactly one of `bare` / `inline` / `agentic`** after trimming surrounding whitespace | Resolve to that profile. |
+| 3 | **File present but empty** (zero bytes, or only whitespace once trimmed) | **Error.** Not treated as "absent". |
+| 4 | **Trimmed contents contain internal whitespace** — a second word, a second line, a space in the middle | **Error.** The file holds one word; anything else is a botched write, not a value to guess at. |
+| 5 | **Trimmed contents are a single token that is not a known profile** (`full`, `none`, `agent`, `AGENTIC`, `Bare`, …) | **Error.** No fuzzy matching, no case folding. |
+| 6 | **File is not a regular file** — a directory, FIFO, socket, or a broken symlink | **Error.** |
+| 7 | **File contents are not valid UTF-8** | **Error.** |
+
+### Whitespace handling (rule 2 in detail)
+
+Leading and trailing whitespace is trimmed before the value is evaluated.
+"Whitespace" is the ASCII set space, tab, newline (`\n`), carriage return
+(`\r`), form feed (`\f`), vertical tab (`\v`) — i.e. C-locale `[:space:]`. So
+all of these resolve to `agentic`:
+
+```
+agentic
+agentic\n
+agentic\n\n\n
+  agentic
+\tagentic\t\n
+```
+
+A **trailing newline is expected and fine** — editors and `printf '%s\n'`
+add one. What is *not* fine is whitespace *inside* the trimmed value:
+
+```
+agentic bare      → error (rule 4: two tokens)
+agentic\nbare      → error (rule 4: second line)
+agen tic           → error (rule 4: internal space)
+```
+
+### Case sensitivity
+
+**Case-sensitive.** Only the lowercase spellings `bare`, `inline`, `agentic`
+are valid. `AGENTIC`, `Agentic`, `BARE` all fall under rule 5 and error.
+
+Rationale: a single canonical spelling is trivial to `grep` for and to
+validate, and it means the shell reader and the Python reader do not each
+need to agree on a case-folding algorithm (Unicode-aware? locale-sensitive?).
+Removing that ambiguity is the entire reason this contract is written down.
+
+### Absent vs. invalid — the load-bearing decision
+
+**Absent resolves to `agentic`. Invalid never does.**
+
+An absent file is the normal state of every checkout made before this feature
+existed, so it has to keep meaning "full behaviour". But an existing file that
+is empty, truncated, multi-line, or holds an unrecognised word is *evidence of
+a problem* — a crashed writer, a half-finished manual edit, a disk-full
+truncation, a merge artifact. Resolving any of those to `agentic` would
+**fail open into the most-privileged profile**: exactly the wrong direction
+for a feature whose purpose is to *withhold* AI tooling on request.
+
+So invalid input **fails loudly** — the reader errors, and the caller is
+expected to stop rather than proceed on a guess. It does not silently
+fall back to `bare` either: a silent downgrade to the most-restrictive
+profile would be almost as hard to debug as a silent upgrade, and would break
+a working `agentic` checkout the first time anything ever truncated the file.
+The contract's answer to "I can't tell what you meant" is to say so, not to
+pick a side.
+
+## The reader
+
+Two implementations, identical semantics, verified against a shared table of
+cases (`test_profile.py` and `test_profile.sh` exercise the same corpus):
+
+| File | For | Entry points |
+|------|-----|--------------|
+| `profile.sh` | the shell; anything that can `source` a POSIX-ish bash file | `dotfiles_profile` (prints the resolved profile, or an error on stderr + return 2); `dotfiles_profile_at_least <profile>` (return 0/1/2); `dotfiles_profile_path` (prints the file path). Running the script directly (`bash profile/profile.sh`) is equivalent to `dotfiles_profile`. |
+| `profile.py` | the Python linker; **and Ansible** (see below) | `resolve_profile(path=None) -> str`; `profile_at_least(current, required) -> bool`; `write_profile(name, path=None, home=None) -> bool`; constants `PROFILES`, `DEFAULT_PROFILE`, `PROFILE_RANK`; exception `ProfileError`. Running the module directly (`python3 profile/profile.py`) prints the resolved profile on stdout and exits 0, or prints `profile: <reason>` on stderr and exits **2**. `--at-least <profile>` exits 0 if satisfied, 1 if not, 2 on any read error. |
+
+There is deliberately **no third parser**. In particular Ansible does **not**
+`lookup('file', ...)` the profile and parse it in Jinja — that would be a
+fourth implementation of these rules, free to drift. Instead Ansible shells
+out to the Python reader and consumes its stdout / return code:
+
+```yaml
+- name: Resolve the active dotfiles profile
+  ansible.builtin.command:
+    cmd: python3 {{ dotfiles_dir }}/profile/profile.py
+  register: _dotfiles_profile
+  changed_when: false
+  failed_when: _dotfiles_profile.rc != 0
+
+- name: Record it as a fact
+  ansible.builtin.set_fact:
+    dotfiles_profile: "{{ _dotfiles_profile.stdout | trim }}"
+
+# gate a task on a minimum level without re-encoding the rank table:
+- name: Something that needs at least inline
+  ansible.builtin.command:
+    cmd: python3 {{ dotfiles_dir }}/profile/profile.py --at-least inline
+  register: _needs_inline
+  changed_when: false
+  failed_when: _needs_inline.rc == 2   # 0 = satisfied, 1 = not, 2 = broken file
+  when: ...
+```
+
+## Security: symlink-ancestry check on write
+
+Established by issue #29 for this repo: any state-marker file that gets
+*written* must have its ancestry checked for attacker-planted symlinks
+**before** any `mkdir(parents=True)` or write. The attack is a symlink dropped
+at, say, `~/.config` (or `~/.config/dotfiles`) that redirects the write to an
+arbitrary file the attacker chooses.
+
+The `profile` file is exactly such a state marker — it is written by the
+future `dotfiles profile <name>` CLI (task 2d), which will call
+`write_profile()` here. So `write_profile()`:
+
+1. Validates the requested name against `PROFILES` first (invalid name raises
+   `ProfileError`, nothing touches the filesystem).
+2. Walks every path component from the file's parent directory up to **and
+   including `$HOME`**, calling `is_symlink()` on each, and checks the file
+   path itself. This happens **before** `mkdir` and **before** the write.
+3. If any component is a symlink: **warn on stderr and skip the write**,
+   returning `False`. It does **not** raise and does **not** abort the
+   caller — the CLI is expected to surface the warning and carry on.
+4. Only if the ancestry is clean does it `mkdir(parents=True, exist_ok=True)`
+   the parent and write atomically (temp file in the same directory +
+   `os.replace`), so a reader never sees a half-written value.
+
+The **readers** (`resolve_profile`, `dotfiles_profile`) do not fail on a
+symlinked ancestor — a read cannot be turned into an arbitrary-file
+overwrite, and users legitimately symlink `~/.config`. They do print a
+one-line warning on stderr when the file or an ancestor up to `$HOME` is a
+symlink, then return the value as normal.

--- a/profile/profile.py
+++ b/profile/profile.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Reader for the dotfiles ``profile`` file contract.
+
+The single source of truth is the file
+
+    ${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/profile
+
+which holds exactly one profile name. See ``profile/README.md`` for the full
+contract; the short version:
+
+* ``bare`` (rank 0) ⊂ ``inline`` (rank 1) ⊂ ``agentic`` (rank 2)
+* file **absent**            -> resolves to ``agentic`` (preserves old behaviour)
+* file empty / multi-token / unknown word / not-a-regular-file / bad UTF-8
+  -> :class:`ProfileError` (never silently falls back to ``agentic``)
+* value is case-sensitive lowercase; surrounding whitespace is trimmed
+
+This module is imported by the Python linker and executed as a script by
+Ansible (``python3 profile/profile.py`` -> profile name on stdout, exit 0;
+error -> stderr, exit 2). It is the only Python implementation of the
+contract; do not add a second parser elsewhere.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable, Optional
+
+__all__ = [
+    "PROFILES",
+    "DEFAULT_PROFILE",
+    "PROFILE_RANK",
+    "ProfileError",
+    "profile_path",
+    "resolve_profile",
+    "profile_at_least",
+    "write_profile",
+]
+
+# Canonical, ordered from least to most capable. Index == rank.
+PROFILES = ("bare", "inline", "agentic")
+DEFAULT_PROFILE = "agentic"
+PROFILE_RANK = {name: rank for rank, name in enumerate(PROFILES)}
+
+# ASCII whitespace only, matching C-locale [:space:] in the shell reader:
+# space, tab, newline, carriage return, form feed, vertical tab.
+_ASCII_WS = " \t\n\r\f\v"
+
+
+class ProfileError(ValueError):
+    """The profile file exists but its contents are not a valid profile.
+
+    Raised for empty / whitespace-only files, multi-token or multi-line
+    contents, unknown words, wrong case, non-regular files and invalid
+    UTF-8. Never raised for an absent file (that resolves to
+    :data:`DEFAULT_PROFILE`).
+    """
+
+
+def profile_path(config_home: Optional[os.PathLike | str] = None) -> Path:
+    """Return the path to the profile file.
+
+    ``config_home`` overrides ``$XDG_CONFIG_HOME`` (an empty env value is
+    treated as unset, matching the shell's ``${XDG_CONFIG_HOME:-...}``).
+    """
+    if config_home is None:
+        config_home = os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config")
+    return Path(config_home) / "dotfiles" / "profile"
+
+
+def _ancestors_to_home(path: Path, home: Optional[Path] = None) -> Iterable[Path]:
+    """Yield ``path`` then each parent, stopping at (and including) ``$HOME``.
+
+    If ``path`` is not under ``$HOME`` the walk stops at the filesystem root.
+    Used for the issue-#29 symlink-ancestry check. Path components are
+    compared, never ``resolve()``d -- resolving would follow the very
+    symlinks this walk exists to detect.
+    """
+    home_abs = (Path(home) if home is not None else Path.home())
+    if not home_abs.is_absolute():
+        home_abs = Path.cwd() / home_abs
+    current = path if path.is_absolute() else Path.cwd() / path
+    while True:
+        yield current
+        parent = current.parent
+        if current == home_abs or parent == current:
+            break
+        current = parent
+
+
+def _symlink_in_ancestry(path: Path, home: Optional[Path] = None) -> Optional[Path]:
+    """Return the first symlink at ``path`` or any ancestor up to ``$HOME``.
+
+    ``None`` if the ancestry is clean.
+    """
+    for component in _ancestors_to_home(path, home=home):
+        try:
+            if component.is_symlink():
+                return component
+        except OSError:
+            # An unreadable component is not, by itself, the symlink attack
+            # this guards against; let the actual read/write surface it.
+            continue
+    return None
+
+
+def _warn(msg: str) -> None:
+    print(f"profile: {msg}", file=sys.stderr)
+
+
+def resolve_profile(
+    path: Optional[os.PathLike | str] = None,
+    *,
+    config_home: Optional[os.PathLike | str] = None,
+    home: Optional[os.PathLike | str] = None,
+) -> str:
+    """Resolve the active profile name.
+
+    Returns one of :data:`PROFILES`. Returns :data:`DEFAULT_PROFILE` when the
+    file is absent. Raises :class:`ProfileError` for any present-but-invalid
+    file (see the class docstring and ``profile/README.md``).
+
+    A symlink at the file or any ancestor up to ``$HOME`` is *not* an error
+    for a read -- it emits a one-line stderr warning and resolution
+    continues.
+    """
+    p = Path(path) if path is not None else profile_path(config_home)
+    home_p = Path(home) if home is not None else None
+
+    is_symlink = False
+    try:
+        is_symlink = p.is_symlink()
+    except OSError:
+        is_symlink = False
+
+    # Rule 1: genuinely absent (and not a broken symlink) -> default.
+    if not is_symlink and not p.exists():
+        return DEFAULT_PROFILE
+
+    offender = _symlink_in_ancestry(p, home=home_p)
+    if offender is not None:
+        _warn(f"{offender} is a symlink; reading the profile through it anyway")
+
+    # Rule 6: must be a regular file (this also rejects broken symlinks,
+    # directories, FIFOs, sockets).
+    if not p.is_file():
+        raise ProfileError(f"{p} is not a regular file")
+
+    # Rule 7: valid UTF-8.
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ProfileError(f"{p} is not valid UTF-8: {exc}") from exc
+
+    value = raw.strip(_ASCII_WS)
+
+    # Rule 3: empty / whitespace-only.
+    if not value:
+        raise ProfileError(f"{p} is empty")
+
+    # Rule 4: exactly one token, no internal whitespace / newlines.
+    if any(ch in _ASCII_WS for ch in value):
+        raise ProfileError(
+            f"{p} contains more than one token ({value!r}); it must hold exactly one profile name"
+        )
+
+    # Rule 5: known, case-sensitive.
+    if value not in PROFILE_RANK:
+        raise ProfileError(
+            f"unknown profile {value!r} in {p}; valid values are {', '.join(PROFILES)}"
+        )
+
+    # Rule 2.
+    return value
+
+
+def profile_at_least(current: str, required: str) -> bool:
+    """True iff ``current`` is at or above ``required`` in the nesting order.
+
+    Both arguments must be valid profile names; anything else is a
+    programming error and raises :class:`ProfileError`.
+    """
+    try:
+        return PROFILE_RANK[current] >= PROFILE_RANK[required]
+    except KeyError as exc:
+        raise ProfileError(f"not a profile name: {exc.args[0]!r}") from None
+
+
+def write_profile(
+    name: str,
+    path: Optional[os.PathLike | str] = None,
+    *,
+    config_home: Optional[os.PathLike | str] = None,
+    home: Optional[os.PathLike | str] = None,
+) -> bool:
+    """Write ``name`` to the profile file, atomically.
+
+    Carries the issue-#29 symlink-ancestry check: before any ``mkdir`` or
+    write, every path component from the file's parent up to and including
+    ``$HOME`` (plus the file path itself) is checked with ``is_symlink()``.
+    If any is a symlink this **warns on stderr and skips the write**,
+    returning ``False`` -- it does not raise and does not abort the caller.
+
+    An invalid ``name`` raises :class:`ProfileError` before touching the
+    filesystem. Returns ``True`` on a successful write.
+    """
+    if name not in PROFILE_RANK:
+        raise ProfileError(
+            f"refusing to write unknown profile {name!r}; valid values are {', '.join(PROFILES)}"
+        )
+
+    p = Path(path) if path is not None else profile_path(config_home)
+    home_p = Path(home) if home is not None else None
+
+    offender = _symlink_in_ancestry(p, home=home_p)
+    if offender is not None:
+        _warn(
+            f"{offender} is a symlink -- refusing to write the profile through it; "
+            f"profile file left unchanged"
+        )
+        return False
+
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+    # Atomic replace so a concurrent reader never sees a partial value.
+    fd, tmp_name = tempfile.mkstemp(dir=str(p.parent), prefix=".profile.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(f"{name}\n")
+        os.replace(tmp_name, p)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return True
+
+
+def _main(argv: list[str]) -> int:
+    at_least = None
+    args = list(argv)
+    if args and args[0] == "--at-least":
+        if len(args) < 2:
+            print("profile: --at-least needs a profile name", file=sys.stderr)
+            return 2
+        at_least = args[1]
+        args = args[2:]
+    if args:
+        print(f"profile: unexpected argument {args[0]!r}", file=sys.stderr)
+        return 2
+
+    try:
+        active = resolve_profile()
+    except ProfileError as exc:
+        print(f"profile: {exc}", file=sys.stderr)
+        return 2
+
+    if at_least is not None:
+        try:
+            ok = profile_at_least(active, at_least)
+        except ProfileError as exc:
+            print(f"profile: {exc}", file=sys.stderr)
+            return 2
+        return 0 if ok else 1
+
+    print(active)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/profile/profile.sh
+++ b/profile/profile.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Reader for the dotfiles `profile` file contract.
+#
+# Source this file to get the functions below, or run it directly
+# (`bash profile/profile.sh`) as a shorthand for `dotfiles_profile`.
+# Safe to source from bash or zsh; sourcing only defines functions.
+#
+# The single source of truth is:
+#     ${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/profile
+# holding exactly one of: bare  <  inline  <  agentic   (nested capabilities)
+#
+#   file absent            -> prints "agentic" (preserves old behaviour)
+#   file empty / >1 token / unknown word / not a regular file
+#                          -> message on stderr, return 2 (never falls back)
+#   value is case-sensitive lowercase; surrounding whitespace is trimmed
+#
+# This is the *shell* implementation of the contract. The Python
+# implementation (profile/profile.py) has identical semantics and is what
+# Ansible and the linker use; profile/test_profile.sh checks this one against
+# the same corpus. See profile/README.md for the full contract.
+
+# --- internals --------------------------------------------------------------
+
+_dotfiles_profile_rank() {
+  case "$1" in
+    bare)    printf '0\n' ;;
+    inline)  printf '1\n' ;;
+    agentic) printf '2\n' ;;
+    *)       return 1 ;;
+  esac
+}
+
+# Read path only: a symlinked file or ancestor cannot turn a read into an
+# arbitrary-file overwrite, and users legitimately symlink ~/.config. So warn
+# and carry on rather than failing. (The *write* path in profile.py skips
+# instead -- see issue #29.)
+_dotfiles_profile_warn_symlinks() {
+  local file="$1" dir parent home
+  home="${HOME%/}"
+  [ -L "$file" ] && printf 'profile: %s is a symlink; reading the profile through it anyway\n' "$file" >&2
+  dir=$(dirname -- "$file")
+  while : ; do
+    [ -L "$dir" ] && printf 'profile: %s is a symlink; reading the profile through it anyway\n' "$dir" >&2
+    [ "$dir" = "$home" ] && break
+    [ "$dir" = "/" ] && break
+    parent=$(dirname -- "$dir")
+    [ "$parent" = "$dir" ] && break
+    dir="$parent"
+  done
+}
+
+# --- public API -----------------------------------------------------------
+
+dotfiles_profile_path() {
+  printf '%s/dotfiles/profile\n' "${XDG_CONFIG_HOME:-$HOME/.config}"
+}
+
+# Print the resolved profile name on stdout (return 0), or print a reason on
+# stderr and return 2.
+dotfiles_profile() {
+  # Byte-oriented, locale-independent matching for the trim and the
+  # whitespace check -- must agree with profile.py's ASCII-only set.
+  local LC_ALL=C
+  local file raw value
+  file=$(dotfiles_profile_path)
+
+  # Rule 1: genuinely absent (and not a broken symlink) -> default.
+  if [ ! -L "$file" ] && [ ! -e "$file" ]; then
+    printf 'agentic\n'
+    return 0
+  fi
+
+  _dotfiles_profile_warn_symlinks "$file"
+
+  # Rule 6: must be a regular file. `test -f` follows symlinks, so this also
+  # rejects a broken symlink, a directory, a FIFO, a socket.
+  if [ ! -f "$file" ]; then
+    printf 'profile: %s is not a regular file\n' "$file" >&2
+    return 2
+  fi
+
+  # $(<file) reads the bytes and strips *only* trailing newlines.
+  if ! raw=$(<"$file"); then
+    printf 'profile: cannot read %s\n' "$file" >&2
+    return 2
+  fi
+
+  # Trim leading, then trailing, ASCII whitespace ([:space:] under LC_ALL=C
+  # is space, tab, \n, \r, \f, \v).
+  value="${raw#"${raw%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+
+  # Rule 3: empty / whitespace-only.
+  if [ -z "$value" ]; then
+    printf 'profile: %s is empty\n' "$file" >&2
+    return 2
+  fi
+
+  # Rule 4: exactly one token -- no internal whitespace or newlines.
+  case "$value" in
+    *[[:space:]]*)
+      printf 'profile: %s contains more than one token; it must hold exactly one profile name\n' "$file" >&2
+      return 2
+      ;;
+  esac
+
+  # Rules 2 & 5: known value, case-sensitive. `[` compares bytes, so invalid
+  # UTF-8 simply fails to match any token and lands in the error branch --
+  # same "this is not a valid profile" outcome as profile.py's explicit
+  # UnicodeDecodeError path.
+  if [ "$value" = bare ] || [ "$value" = inline ] || [ "$value" = agentic ]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+
+  printf 'profile: unknown profile %s in %s; valid values are bare, inline, agentic\n' "$value" "$file" >&2
+  return 2
+}
+
+# Return 0 if the active profile is at or above <required> in the nesting
+# order, 1 if it is below, 2 on a read error or a bad argument.
+dotfiles_profile_at_least() {
+  local required="$1" active req_rank act_rank
+  if ! req_rank=$(_dotfiles_profile_rank "$required"); then
+    printf 'profile: not a profile name: %s\n' "$required" >&2
+    return 2
+  fi
+  if ! active=$(dotfiles_profile); then
+    return 2
+  fi
+  act_rank=$(_dotfiles_profile_rank "$active")
+  [ "$act_rank" -ge "$req_rank" ]
+}
+
+# Executed directly (not sourced)? Behave like `dotfiles_profile`. This test
+# is bash-specific; when sourced from bash or zsh it is simply skipped and
+# only the functions are defined.
+if [ -n "${BASH_SOURCE:-}" ] && [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  dotfiles_profile "$@"
+  exit $?
+fi

--- a/profile/run-tests.sh
+++ b/profile/run-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run both reader test suites for the `profile` file contract.
+#   bash profile/run-tests.sh
+set -euo pipefail
+
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+echo "=== python: profile/test_profile.py ==="
+python3 "$DIR/test_profile.py"
+
+echo
+echo "=== shell: profile/test_profile.sh ==="
+bash "$DIR/test_profile.sh"

--- a/profile/test_profile.py
+++ b/profile/test_profile.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Tests for profile/profile.py -- one assertion per rule in the contract.
+
+Run directly: ``python3 profile/test_profile.py`` (uses stdlib unittest, no
+third-party deps). ``profile/run-tests.sh`` runs this plus the shell suite.
+"""
+
+import contextlib
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import profile as mod  # noqa: E402
+
+
+class ResolveTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.path = self.tmp / ".config" / "dotfiles" / "profile"
+        self.path.parent.mkdir(parents=True)
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, data):
+        if isinstance(data, bytes):
+            self.path.write_bytes(data)
+        else:
+            self.path.write_text(data, encoding="utf-8")
+
+    def resolve(self):
+        # swallow the symlink warning lines; assertions target the return value
+        with contextlib.redirect_stderr(io.StringIO()):
+            return mod.resolve_profile(self.path, home=self.tmp)
+
+    # rule 1
+    def test_absent_resolves_to_agentic(self):
+        self.assertFalse(self.path.exists())
+        self.assertEqual(self.resolve(), "agentic")
+
+    # rule 2 -- the three canonical values
+    def test_each_valid_value(self):
+        for name in ("bare", "inline", "agentic"):
+            self.write(name)
+            self.assertEqual(self.resolve(), name)
+
+    # rule 2 -- trailing / surrounding whitespace is trimmed
+    def test_trailing_newline_ok(self):
+        self.write("agentic\n")
+        self.assertEqual(self.resolve(), "agentic")
+
+    def test_many_trailing_newlines_ok(self):
+        self.write("agentic\n\n\n")
+        self.assertEqual(self.resolve(), "agentic")
+
+    def test_leading_and_trailing_blanks_ok(self):
+        self.write("  inline  ")
+        self.assertEqual(self.resolve(), "inline")
+
+    def test_tabs_and_crlf_trimmed(self):
+        self.write("\t\r\nbare\r\n\t")
+        self.assertEqual(self.resolve(), "bare")
+
+    # rule 3
+    def test_empty_file_errors(self):
+        self.write("")
+        with self.assertRaises(mod.ProfileError):
+            self.resolve()
+
+    def test_whitespace_only_errors(self):
+        self.write("   \n\t\n")
+        with self.assertRaises(mod.ProfileError):
+            self.resolve()
+
+    # rule 4
+    def test_two_words_error(self):
+        self.write("agentic bare")
+        with self.assertRaises(mod.ProfileError):
+            self.resolve()
+
+    def test_second_line_error(self):
+        self.write("agentic\nbare\n")
+        with self.assertRaises(mod.ProfileError):
+            self.resolve()
+
+    def test_internal_space_error(self):
+        self.write("agen tic")
+        with self.assertRaises(mod.ProfileError):
+            self.resolve()
+
+    # rule 5 -- unknown words
+    def test_unknown_word_error(self):
+        for bad in ("full", "none", "agent", "on", "yes", "default"):
+            self.write(bad)
+            with self.assertRaises(mod.ProfileError):
+                self.resolve()
+
+    # rule 5 -- case sensitivity
+    def test_case_sensitive(self):
+        for bad in ("AGENTIC", "Agentic", "BARE", "Bare", "Inline", "INLINE"):
+            self.write(bad)
+            with self.assertRaises(mod.ProfileError):
+                self.resolve()
+
+    # rule 6 -- not a regular file
+    def test_directory_at_path_errors(self):
+        self.path.rmdir() if self.path.exists() else None
+        self.path.mkdir()
+        with self.assertRaises(mod.ProfileError):
+            self.resolve()
+
+    def test_broken_symlink_errors(self):
+        self.path.symlink_to(self.tmp / "does-not-exist")
+        with self.assertRaises(mod.ProfileError):
+            self.resolve()
+
+    # rule 7
+    def test_invalid_utf8_errors(self):
+        self.write(b"\xff\xfe\xfa")
+        with self.assertRaises(mod.ProfileError):
+            self.resolve()
+
+    # never silently falls open to agentic on a bad value
+    def test_invalid_never_returns_agentic(self):
+        for bad in ("", "   ", "AGENTIC", "full", "agentic bare"):
+            self.write(bad)
+            with self.assertRaises(mod.ProfileError):
+                self.resolve()
+
+
+class SymlinkAncestryReadTests(unittest.TestCase):
+    """A symlink in the ancestry warns but does not fail a *read*."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_symlinked_file_warns_and_still_reads(self):
+        real = self.tmp / "real-profile"
+        real.write_text("inline\n", encoding="utf-8")
+        link = self.tmp / ".config" / "dotfiles" / "profile"
+        link.parent.mkdir(parents=True)
+        link.symlink_to(real)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            got = mod.resolve_profile(link, home=self.tmp)
+        self.assertEqual(got, "inline")
+        self.assertIn("is a symlink", err.getvalue())
+
+    def test_symlinked_ancestor_warns_and_still_reads(self):
+        realdir = self.tmp / "real-config"
+        (realdir / "dotfiles").mkdir(parents=True)
+        (realdir / "dotfiles" / "profile").write_text("bare\n", encoding="utf-8")
+        (self.tmp / ".config").symlink_to(realdir)
+        path = self.tmp / ".config" / "dotfiles" / "profile"
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            got = mod.resolve_profile(path, home=self.tmp)
+        self.assertEqual(got, "bare")
+        self.assertIn("is a symlink", err.getvalue())
+
+
+class AtLeastTests(unittest.TestCase):
+    def test_nesting_true(self):
+        self.assertTrue(mod.profile_at_least("bare", "bare"))
+        self.assertTrue(mod.profile_at_least("inline", "bare"))
+        self.assertTrue(mod.profile_at_least("agentic", "bare"))
+        self.assertTrue(mod.profile_at_least("inline", "inline"))
+        self.assertTrue(mod.profile_at_least("agentic", "inline"))
+        self.assertTrue(mod.profile_at_least("agentic", "agentic"))
+
+    def test_nesting_false(self):
+        self.assertFalse(mod.profile_at_least("bare", "inline"))
+        self.assertFalse(mod.profile_at_least("bare", "agentic"))
+        self.assertFalse(mod.profile_at_least("inline", "agentic"))
+
+    def test_bad_name_raises(self):
+        with self.assertRaises(mod.ProfileError):
+            mod.profile_at_least("agentic", "full")
+        with self.assertRaises(mod.ProfileError):
+            mod.profile_at_least("AGENTIC", "bare")
+
+
+class ProfilePathTests(unittest.TestCase):
+    def test_uses_xdg_config_home(self):
+        with _env(XDG_CONFIG_HOME="/somewhere/cfg"):
+            self.assertEqual(
+                mod.profile_path(), Path("/somewhere/cfg/dotfiles/profile")
+            )
+
+    def test_empty_xdg_falls_back_to_home_config(self):
+        with _env(XDG_CONFIG_HOME=""):
+            self.assertEqual(
+                mod.profile_path(), Path.home() / ".config" / "dotfiles" / "profile"
+            )
+
+    def test_explicit_override_wins(self):
+        with _env(XDG_CONFIG_HOME="/somewhere/cfg"):
+            self.assertEqual(
+                mod.profile_path("/other"), Path("/other/dotfiles/profile")
+            )
+
+
+class WriteTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.path = self.tmp / ".config" / "dotfiles" / "profile"
+
+    def test_writes_and_creates_parents(self):
+        self.assertFalse(self.path.parent.exists())
+        ok = mod.write_profile("bare", self.path, home=self.tmp)
+        self.assertTrue(ok)
+        self.assertEqual(self.path.read_text(encoding="utf-8"), "bare\n")
+
+    def test_written_value_round_trips_through_reader(self):
+        mod.write_profile("inline", self.path, home=self.tmp)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(
+                mod.resolve_profile(self.path, home=self.tmp), "inline"
+            )
+
+    def test_overwrite_is_atomic_replace(self):
+        mod.write_profile("agentic", self.path, home=self.tmp)
+        mod.write_profile("bare", self.path, home=self.tmp)
+        self.assertEqual(self.path.read_text(encoding="utf-8"), "bare\n")
+        # no stray temp files left behind
+        leftovers = [p.name for p in self.path.parent.iterdir() if p.name != "profile"]
+        self.assertEqual(leftovers, [])
+
+    def test_invalid_name_raises_and_writes_nothing(self):
+        with self.assertRaises(mod.ProfileError):
+            mod.write_profile("full", self.path, home=self.tmp)
+        with self.assertRaises(mod.ProfileError):
+            mod.write_profile("AGENTIC", self.path, home=self.tmp)
+        self.assertFalse(self.path.exists())
+        self.assertFalse(self.path.parent.exists())
+
+    def test_symlinked_ancestor_skips_write_and_warns(self):
+        # ~/.config is an attacker-planted symlink to a dir they control
+        evil = self.tmp / "evil"
+        evil.mkdir()
+        (self.tmp / ".config").symlink_to(evil)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            ok = mod.write_profile("agentic", self.path, home=self.tmp)
+        self.assertFalse(ok)
+        self.assertIn("is a symlink", err.getvalue())
+        self.assertIn("refusing to write", err.getvalue())
+        # nothing was written through the symlink
+        self.assertFalse((evil / "dotfiles").exists())
+
+    def test_symlinked_file_itself_skips_write(self):
+        self.path.parent.mkdir(parents=True)
+        target = self.tmp / "target"
+        self.path.symlink_to(target)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            ok = mod.write_profile("bare", self.path, home=self.tmp)
+        self.assertFalse(ok)
+        self.assertFalse(target.exists())
+
+    def test_symlink_check_runs_before_mkdir(self):
+        # deeper: ~/.config/dotfiles would be created by mkdir(parents=True);
+        # the symlink is one level up, so the check must fire before mkdir.
+        evil = self.tmp / "evil"
+        evil.mkdir()
+        (self.tmp / ".config").symlink_to(evil)
+        with contextlib.redirect_stderr(io.StringIO()):
+            mod.write_profile("bare", self.path, home=self.tmp)
+        self.assertFalse((evil / "dotfiles").exists())
+
+
+class CliTests(unittest.TestCase):
+    """Exercise the actual `python3 profile.py` entry point Ansible uses."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.cfg = self.tmp / "cfg"
+        (self.cfg / "dotfiles").mkdir(parents=True)
+        self.path = self.cfg / "dotfiles" / "profile"
+        self.addCleanup(self._tmp.cleanup)
+
+    def run_cli(self, *args):
+        env = dict(os.environ)
+        env["XDG_CONFIG_HOME"] = str(self.cfg)
+        return subprocess.run(
+            [sys.executable, str(HERE / "profile.py"), *args],
+            capture_output=True, text=True, env=env,
+        )
+
+    def test_absent_prints_agentic_exit_0(self):
+        r = self.run_cli()
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), "agentic")
+
+    def test_valid_prints_value_exit_0(self):
+        self.path.write_text("inline\n", encoding="utf-8")
+        r = self.run_cli()
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), "inline")
+
+    def test_invalid_exit_2_stderr(self):
+        self.path.write_text("full\n", encoding="utf-8")
+        r = self.run_cli()
+        self.assertEqual(r.returncode, 2)
+        self.assertEqual(r.stdout, "")
+        self.assertIn("profile:", r.stderr)
+
+    def test_empty_exit_2(self):
+        self.path.write_text("", encoding="utf-8")
+        r = self.run_cli()
+        self.assertEqual(r.returncode, 2)
+
+    def test_at_least_satisfied_exit_0(self):
+        self.path.write_text("agentic\n", encoding="utf-8")
+        self.assertEqual(self.run_cli("--at-least", "inline").returncode, 0)
+
+    def test_at_least_not_satisfied_exit_1(self):
+        self.path.write_text("bare\n", encoding="utf-8")
+        self.assertEqual(self.run_cli("--at-least", "agentic").returncode, 1)
+
+    def test_at_least_broken_file_exit_2(self):
+        self.path.write_text("nonsense\n", encoding="utf-8")
+        self.assertEqual(self.run_cli("--at-least", "bare").returncode, 2)
+
+    def test_at_least_absent_uses_default(self):
+        # absent -> agentic, so "--at-least inline" is satisfied
+        self.assertEqual(self.run_cli("--at-least", "inline").returncode, 0)
+
+    def test_bad_argument_exit_2(self):
+        self.assertEqual(self.run_cli("--bogus").returncode, 2)
+
+
+@contextlib.contextmanager
+def _env(**kw):
+    saved = {k: os.environ.get(k) for k in kw}
+    try:
+        for k, v in kw.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/profile/test_profile.sh
+++ b/profile/test_profile.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Tests for profile/profile.sh -- the same corpus as test_profile.py, so the
+# two readers cannot drift apart on an edge case.
+#
+# Run directly: `bash profile/test_profile.sh`. Exits non-zero if any case
+# fails. `profile/run-tests.sh` runs this plus the Python suite.
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+READER="$SCRIPT_DIR/profile.sh"
+
+pass=0
+fail=0
+ok()  { pass=$((pass + 1)); printf 'ok   - %s\n' "$1"; }
+bad() { fail=$((fail + 1)); printf 'FAIL - %s\n       expected: %s\n       actual:   %s\n' "$1" "$2" "$3"; }
+
+# Run the reader as a standalone script against a freshly built config dir.
+#   $1 = mode, $2 = payload (for RAW/RAWNONL/BYTES)
+# Sets OUT, ERR, RC.
+resolve_case() {
+  local mode="$1" payload="${2-}"
+  local tmp cfg pf
+  tmp=$(mktemp -d)
+  cfg="$tmp/.config"
+  mkdir -p "$cfg/dotfiles"
+  pf="$cfg/dotfiles/profile"
+  case "$mode" in
+    ABSENT)  : ;;
+    DIR)     rm -f "$pf"; mkdir "$pf" ;;
+    BROKEN)  ln -s "$tmp/does-not-exist" "$pf" ;;
+    LINKFILE)
+      printf 'inline\n' > "$tmp/real-profile"
+      ln -s "$tmp/real-profile" "$pf" ;;
+    LINKANCESTOR)
+      rm -rf "$cfg"
+      mkdir -p "$tmp/real-config/dotfiles"
+      printf 'bare\n' > "$tmp/real-config/dotfiles/profile"
+      ln -s "$tmp/real-config" "$cfg" ;;
+    RAW)      printf '%b' "$payload" > "$pf" ;;   # interprets \n \t \r \xNN
+    RAWNONL)  printf '%s' "$payload" > "$pf" ;;   # exact bytes, no newline
+    *) echo "unknown mode $mode" >&2; exit 99 ;;
+  esac
+  OUT=$(HOME="$tmp" XDG_CONFIG_HOME="$cfg" bash "$READER" 2>"$tmp/err"); RC=$?
+  ERR=$(cat "$tmp/err")
+  rm -rf "$tmp"
+}
+
+assert_value() { # desc expected
+  if [ "$RC" -eq 0 ] && [ "$OUT" = "$2" ] && [ -z "$ERR" ]; then
+    ok "$1"
+  else
+    bad "$1" "rc=0 out='$2' err=''" "rc=$RC out='$OUT' err='$ERR'"
+  fi
+}
+
+assert_error() { # desc
+  if [ "$RC" -eq 2 ] && [ -z "$OUT" ] && [ -n "$ERR" ]; then
+    ok "$1"
+  else
+    bad "$1" "rc=2 out='' err=<nonempty>" "rc=$RC out='$OUT' err='$ERR'"
+  fi
+}
+
+# ---- rule 1: absent -> agentic ------------------------------------------
+resolve_case ABSENT;            assert_value "absent file resolves to agentic" "agentic"
+
+# ---- rule 2: the three canonical values --------------------------------
+resolve_case RAW "bare";        assert_value "value 'bare'" "bare"
+resolve_case RAW "inline";      assert_value "value 'inline'" "inline"
+resolve_case RAW "agentic";     assert_value "value 'agentic'" "agentic"
+
+# ---- rule 2: surrounding whitespace is trimmed -----------------------
+resolve_case RAW  'agentic\n';        assert_value "trailing newline trimmed" "agentic"
+resolve_case RAW  'agentic\n\n\n';    assert_value "many trailing newlines trimmed" "agentic"
+resolve_case RAWNONL '  inline  ';    assert_value "leading+trailing spaces trimmed" "inline"
+resolve_case RAW  '\t\r\nbare\r\n\t'; assert_value "tabs and CRLF trimmed" "bare"
+
+# ---- rule 3: empty / whitespace-only ---------------------------------
+resolve_case RAWNONL '';             assert_error "empty file errors"
+resolve_case RAW  '   \n\t\n';       assert_error "whitespace-only file errors"
+
+# ---- rule 4: more than one token ------------------------------------
+resolve_case RAWNONL 'agentic bare'; assert_error "two words error"
+resolve_case RAW  'agentic\nbare\n'; assert_error "second line error"
+resolve_case RAWNONL 'agen tic';     assert_error "internal space error"
+
+# ---- rule 5: unknown words ----------------------------------------
+for w in full none agent on yes default; do
+  resolve_case RAWNONL "$w";         assert_error "unknown word '$w' errors"
+done
+
+# ---- rule 5: case sensitivity -------------------------------------
+for w in AGENTIC Agentic BARE Bare Inline INLINE; do
+  resolve_case RAWNONL "$w";         assert_error "wrong-case '$w' errors"
+done
+
+# ---- rule 6: not a regular file ---------------------------------
+resolve_case DIR;                    assert_error "directory at path errors"
+resolve_case BROKEN;                 assert_error "broken symlink errors"
+
+# ---- rule 7: invalid UTF-8 (bash: fails to match any token -> error) --
+resolve_case RAW '\xff\xfe\xfa';     assert_error "invalid UTF-8 errors"
+
+# ---- symlink in ancestry: read warns but still resolves -----------
+resolve_case LINKFILE
+if [ "$RC" -eq 0 ] && [ "$OUT" = "inline" ] && printf '%s' "$ERR" | grep -q "is a symlink"; then
+  ok "symlinked file: warns on stderr, still resolves"
+else
+  bad "symlinked file: warns on stderr, still resolves" "rc=0 out=inline err~=symlink" "rc=$RC out='$OUT' err='$ERR'"
+fi
+
+resolve_case LINKANCESTOR
+if [ "$RC" -eq 0 ] && [ "$OUT" = "bare" ] && printf '%s' "$ERR" | grep -q "is a symlink"; then
+  ok "symlinked ancestor: warns on stderr, still resolves"
+else
+  bad "symlinked ancestor: warns on stderr, still resolves" "rc=0 out=bare err~=symlink" "rc=$RC out='$OUT' err='$ERR'"
+fi
+
+# ---- dotfiles_profile_path honours XDG_CONFIG_HOME ---------------
+got=$(XDG_CONFIG_HOME=/somewhere/cfg bash -c ". '$READER'; dotfiles_profile_path")
+if [ "$got" = "/somewhere/cfg/dotfiles/profile" ]; then
+  ok "dotfiles_profile_path uses XDG_CONFIG_HOME"
+else
+  bad "dotfiles_profile_path uses XDG_CONFIG_HOME" "/somewhere/cfg/dotfiles/profile" "$got"
+fi
+
+# ---- dotfiles_profile_at_least: nesting ----------------------------
+at_least_case() { # value required -> RC
+  local tmp
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/.config/dotfiles"
+  printf '%s\n' "$1" > "$tmp/.config/dotfiles/profile"
+  # shellcheck source=/dev/null  # $READER is resolved at runtime
+  # shellcheck disable=SC2030,SC2031  # env vars scoped to this subshell on purpose
+  ( export HOME="$tmp" XDG_CONFIG_HOME="$tmp/.config"; . "$READER"; dotfiles_profile_at_least "$2" )
+  RC=$?
+  rm -rf "$tmp"
+}
+assert_rc() { # desc expected_rc
+  if [ "$RC" -eq "$2" ]; then ok "$1"; else bad "$1" "rc=$2" "rc=$RC"; fi
+}
+
+at_least_case bare    bare;    assert_rc "at_least: bare >= bare" 0
+at_least_case inline  bare;    assert_rc "at_least: inline >= bare" 0
+at_least_case agentic bare;    assert_rc "at_least: agentic >= bare" 0
+at_least_case inline  inline;  assert_rc "at_least: inline >= inline" 0
+at_least_case agentic inline;  assert_rc "at_least: agentic >= inline" 0
+at_least_case bare    inline;  assert_rc "at_least: bare < inline" 1
+at_least_case bare    agentic; assert_rc "at_least: bare < agentic" 1
+at_least_case inline  agentic; assert_rc "at_least: inline < agentic" 1
+at_least_case agentic full;    assert_rc "at_least: bad required name -> rc 2" 2
+at_least_case nonsense bare;   assert_rc "at_least: broken profile file -> rc 2" 2
+
+# ---- summary ----------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Task 0b of the **provisioning split** epic. Adds the contract for the
`profile` state-marker file and a small shared reader. **No consumer is
wired up here** — the shell gate, the Python linker, the nvim `copilot.lua`
gate and the `dotfiles profile <name>` CLI are all later tasks (2a/2b/2c/2d).

The file — one word at `${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/profile` —
selects one of three strictly nested capability profiles:

```
bare (rank 0)  ⊂  inline (rank 1)  ⊂  agentic (rank 2)
```

## Files

| Path | Role |
|------|------|
| `profile/README.md` | the specification — valid values, nesting/rank relation, and a decisive rule for every edge case |
| `profile/profile.py` | Python reader: `resolve_profile` / `profile_at_least` / `write_profile`, plus a `python3 profile/profile.py` CLI entry point |
| `profile/profile.sh` | shell reader with identical semantics: `dotfiles_profile` / `dotfiles_profile_at_least` / `dotfiles_profile_path`; source-safe under bash and zsh |
| `profile/test_profile.py`, `profile/test_profile.sh` | the same case corpus against both readers |
| `profile/run-tests.sh` | runs both suites |

Two implementations, not three: **Ansible consumes the Python reader** by
shelling out (`command:` + `register` + `failed_when: rc != 0`), not by
`lookup('file')` + Jinja parsing. A Jinja parser would be a fourth
implementation free to drift. The `README` documents the exact Ansible
usage.

## Contract decisions

- **Absent file → `agentic`.** Preserves today's behaviour for every
  checkout predating this feature. This is the *only* implicit default.
- **Any present-but-invalid file fails loudly** — empty, whitespace-only,
  multi-token, multi-line, unknown word, wrong case, non-regular file, or
  invalid UTF-8. The reader errors (exit 2, nothing on stdout); it does not
  fall back.
  - Falling back to `agentic` would **fail open into the most-privileged
    profile** — the exact opposite of a feature whose job is to *withhold*
    AI tooling on request.
  - Falling back to `bare` (fail-closed) was considered and rejected: a
    silent downgrade is nearly as hard to debug as a silent upgrade, and it
    would break a working `agentic` checkout the first time anything ever
    truncated the file. The contract's answer to "I can't tell what you
    meant" is to say so, not to pick a side.
- **Case-sensitive lowercase.** Only `bare` / `inline` / `agentic`.
  `AGENTIC`, `Bare`, … are errors. A single canonical spelling keeps the two
  readers from each needing to agree on a case-folding algorithm.
- **Surrounding ASCII whitespace is trimmed** (`[:space:]` under `LC_ALL=C`
  in shell; the explicit set `" \t\n\r\f\v"` in Python). A trailing newline
  is expected and fine; whitespace *inside* the trimmed value is an error.

## Security — issue #29 symlink-ancestry check

The `profile` file is written by the future `dotfiles profile <name>` CLI
(task 2d), so `write_profile()` carries the check issue #29 established:

- Before any `mkdir(parents=True)` or write, it walks every path component
  from the file's parent **up to and including `$HOME`**, plus the file path
  itself, calling `is_symlink()`.
- A symlink anywhere in that ancestry → **warn on stderr and skip the
  write** (return `False`). It does not raise and does not abort the caller.
- Covered by tests, including `test_symlink_check_runs_before_mkdir` (proves
  no directory is created through a symlinked `~/.config`) and the
  end-to-end check that an attacker-controlled target directory stays empty.

The *readers* only warn on a symlinked ancestor and still return the value —
a read cannot be turned into an arbitrary-file overwrite, and users
legitimately symlink `~/.config`.

## Verification

- `python3 profile/test_profile.py` — **41 passed** (`OK`).
- `bash profile/test_profile.sh` — **41 passed, 0 failed**.
- `shellcheck` on all three shell files — clean (rc 0).
- End-to-end against a real filesystem: writer creates file + parents,
  `cat` shows exactly the written word, both readers + the sourced shell
  form agree; `--at-least` returns 0/1 correctly; an invalid value (`FULL`)
  gives exit 2 and empty stdout from **both** readers (never `agentic`);
  the writer refuses a symlinked `~/.config`, returns `False`, and leaves
  the attacker-controlled directory empty.
- `resolve_profile` / `profile.sh` run against the real `$HOME` (no profile
  file present) both print `agentic`.
- zsh can `source profile/profile.sh` and call all three functions.

## Out of scope (untouched)

`install.py`, `install.ps1`, `install.sh`, `hooks/pre-commit`,
`tools/sync-agent.sh`, everything under `claude/`. No `dotfiles profile`
CLI, no nvim gate, no linker wiring.