### PR TITLE
feat(provision): Layer 1 Ansible skeleton + packages role (spike)

### DIFF
--- a/provision/README.md
+++ b/provision/README.md
@@ -21,8 +21,8 @@ provision/
 ├── ansible.cfg              # local-only, single host, no vault yet
 ├── inventory/
 │   ├── hosts.yml            # one host: localhost, connection=local
-│   └── group_vars/all.yml   # profile definitions (bare ⊂ inline ⊂ agentic)
-├── site.yml                 # entry point; -e profile=<tier>
+│   └── group_vars/all.yml   # doc stub — the profile model lives in profile/
+├── site.yml                 # entry point; reads profile/, -e profile=<tier> overrides
 └── roles/
     └── packages/            # the spiked role
 ```
@@ -31,14 +31,22 @@ provision/
 
 ```sh
 # Dry run (always do this first):
+ansible-playbook site.yml --check --diff
+
+# Override the on-disk profile for a run:
 ansible-playbook site.yml -e profile=inline --check --diff
 
 # For real:
 ansible-playbook site.yml -e profile=agentic
 ```
 
-`profile` is required-ish: it defaults to `bare`, and an unknown value fails
-the play in `pre_tasks` before any package work happens.
+`profile` is **not** defined in this tree. With no `-e profile=`, `site.yml`
+shells out to the shared reader (`profile/profile.py`, PR #53), which reads
+`${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/profile` and resolves an **absent
+file to `agentic`** per `profile/README.md`. `-e profile=<tier>` overrides the
+file for that run. An unknown value — in the file or passed with `-e` — fails
+the play in `pre_tasks`, loudly, before any package work happens; the reader
+is the only validator (this play does not re-implement the rules).
 
 ### Profiles
 

--- a/provision/README.md
+++ b/provision/README.md
@@ -1,0 +1,101 @@
+# provision/ — Layer 1: machine state (Ansible)
+
+Part of the three-layer provisioning split:
+
+| Layer | Dir          | What                                             | Tooling            |
+| ----- | ------------ | ------------------------------------------------ | ------------------ |
+| 0     | `bootstrap/` | Get a bare box to "can run Ansible"              | imperative script  |
+| **1** | `provision/` | **Machine state: packages, services, OS config** | **Ansible (this)** |
+| 2     | `dotfiles/`  | Symlink farm for config files                   | no Ansible dep     |
+
+Ansible (not Nix) is the locked choice for Layer 1.
+
+This directory is currently a **spike**: it wires up exactly one role,
+`packages`, end to end so the shape of Layer 1 is proven before the rest of
+`install.py` is ported.
+
+## Layout
+
+```
+provision/
+├── ansible.cfg              # local-only, single host, no vault yet
+├── inventory/
+│   ├── hosts.yml            # one host: localhost, connection=local
+│   └── group_vars/all.yml   # profile definitions (bare ⊂ inline ⊂ agentic)
+├── site.yml                 # entry point; -e profile=<tier>
+└── roles/
+    └── packages/            # the spiked role
+```
+
+## Running it
+
+```sh
+# Dry run (always do this first):
+ansible-playbook site.yml -e profile=inline --check --diff
+
+# For real:
+ansible-playbook site.yml -e profile=agentic
+```
+
+`profile` is required-ish: it defaults to `bare`, and an unknown value fails
+the play in `pre_tasks` before any package work happens.
+
+### Profiles
+
+Strictly nested — each tier is a superset of the one before:
+
+| Profile   | Adds                                          |
+| --------- | -------------------------------------------- |
+| `bare`    | shell + CLI toolchain from `packages/apt.txt` (no AI tooling) |
+| `inline`  | `bare` + AI CLIs (`claude`, `copilot`)       |
+| `agentic` | `inline` + (future: local agent runtime bits) |
+
+## Source of truth
+
+The `packages` role does **not** keep its own package lists. It reads the
+manifests that already exist at the repo root:
+
+| Manifest             | OS family | Status in this spike           |
+| -------------------- | --------- | ------------------------------ |
+| `packages/apt.txt`   | Debian    | **verified on WSL** (`--check --diff`) |
+| `packages/Brewfile`  | macOS     | **written but UNVERIFIED** — no Mac was reachable; never executed |
+| `packages/winget.txt` | Windows   | **deferred to Phase 3** — not consumed here |
+
+## Verifying on WSL
+
+`ansible-playbook ... --check --diff` needs two things the reference WSL box
+did not have out of the box:
+
+1. **`python3-apt`** — the `ansible.builtin.apt` module refuses to run in check
+   mode without it. It is not pip-installable; on a normal machine
+   `sudo apt-get install python3-apt` (or Ansible's own
+   `auto_install_module_deps` on a non-check run) covers it.
+2. **Privilege for the apt task** — a real run needs root. For a dry run on a
+   box without passwordless sudo, override:
+
+   ```sh
+   ansible-playbook site.yml -e profile=inline --check --diff \
+     -e packages_apt_become=false -e packages_apt_update_cache=false
+   ```
+
+## Upstream-contribution candidates
+
+Per the standing "contribute the gap, don't shim it" preference:
+
+- **`community.general` has no Brewfile-native module.** `homebrew`,
+  `homebrew_cask`, `homebrew_tap` exist; there is no `homebrew_bundle`. The
+  role parses `packages/Brewfile` itself as a result. A first-class
+  `community.general.homebrew_bundle` (wrapping `brew bundle` with proper
+  check-mode / diff support) would remove that parsing and is worth proposing
+  upstream.
+- **`ansible.builtin.apt` check-mode hard-depends on `python3-apt`** with only
+  a runtime error to guide you. Not a bug exactly, but the ergonomics on a
+  fresh WSL/Debian box (where the package is absent and sudo may be
+  password-gated) are poor. Worth a docs/UX issue upstream.
+
+## Not done here (by design)
+
+- winget / Windows branch — Phase 3.
+- Any role other than `packages`.
+- `bootstrap/` and `dotfiles/` layers.
+- Porting the rest of `install.py`.

--- a/provision/ansible.cfg
+++ b/provision/ansible.cfg
@@ -11,7 +11,10 @@
 inventory            = inventory/hosts.yml
 roles_path           = roles
 retry_files_enabled  = False
-host_key_checking    = False
+# host_key_checking is deliberately left at its secure Ansible default (True).
+# This config is inherited by every later role; a disabled value here would
+# silently turn SSH host-key verification off the moment a remote host enters
+# the inventory.
 nocows               = True
 display_skipped_hosts = False
 

--- a/provision/ansible.cfg
+++ b/provision/ansible.cfg
@@ -1,0 +1,28 @@
+# Ansible configuration for the Layer 1 (machine state) provisioner.
+#
+# Layer 0 (bootstrap/) is imperative and runs first; Layer 2 (dotfiles/) is a
+# pure symlink farm with no Ansible dependency. This config only governs the
+# middle layer.
+#
+# Everything here is deliberately scoped to a single local host. There is no
+# SSH, no vault, no dynamic inventory yet -- this is the packages spike.
+
+[defaults]
+inventory            = inventory/hosts.yml
+roles_path           = roles
+retry_files_enabled  = False
+host_key_checking    = False
+nocows               = True
+display_skipped_hosts = False
+
+# Discover the interpreter instead of pinning it: on WSL/Debian the useful
+# interpreter is the system python3 (it can see python3-apt), which is not the
+# same interpreter that runs ansible-playbook when Ansible is installed via
+# pipx. auto_silent keeps discovery but drops the warning.
+interpreter_python   = auto_silent
+
+[privilege_escalation]
+# The apt tasks escalate per-task with `become: true`. Nothing else needs root.
+become        = False
+become_method = sudo
+become_ask_pass = False

--- a/provision/inventory/group_vars/all.yml
+++ b/provision/inventory/group_vars/all.yml
@@ -1,24 +1,15 @@
 ---
 # ── Profiles ──────────────────────────────────────────────────────────────────
-# The three profiles are strictly nested: bare ⊂ inline ⊂ agentic.
+# The profile model (bare ⊂ inline ⊂ agentic, the rank table, the "file absent
+# ⇒ agentic" default, and all the validation) lives in ONE place: profile/ at
+# the repo root, merged via PR #53. See profile/README.md for the contract.
 #
-#   bare     minimal usable shell + CLI toolchain, no AI tooling
-#   inline   bare + AI CLIs (editor-adjacent / "inline" assistance)
-#   agentic  inline + everything needed to run agents locally
+# This playbook does NOT re-implement any of that. site.yml shells out to the
+# shared reader (`python3 profile/profile.py`) exactly as profile/README.md
+# documents for Ansible, and uses `profile/profile.py --at-least <tier>` for
+# the AI-CLI gating decision. The resolved value is published by site.yml as
+# the `dotfiles_profile` fact and the gate as the `want_ai_clis` fact.
 #
-# Because they nest, a role never asks "which profile exactly?" -- it asks
-# "is feature X in scope at or below the selected tier?". `profile_rank`
-# turns the name into an ordinal so `>=` comparisons work.
-profile: bare
-
-profile_ranks:
-  bare: 0
-  inline: 1
-  agentic: 2
-
-# .get() so an unknown profile resolves to -1 instead of raising, letting the
-# assert in site.yml report a clean error message.
-profile_rank: "{{ profile_ranks.get(profile, -1) }}"
-
-# Convenience predicate used by the packages role. AI CLIs come in at `inline`.
-want_ai_clis: "{{ profile_rank | int >= profile_ranks.inline }}"
+# There are deliberately no `profile`, `profile_ranks`, `profile_rank` or
+# `want_ai_clis` definitions here any more — a second parser is exactly what
+# PR #53 set out to prevent.

--- a/provision/inventory/group_vars/all.yml
+++ b/provision/inventory/group_vars/all.yml
@@ -1,0 +1,24 @@
+---
+# ── Profiles ──────────────────────────────────────────────────────────────────
+# The three profiles are strictly nested: bare ⊂ inline ⊂ agentic.
+#
+#   bare     minimal usable shell + CLI toolchain, no AI tooling
+#   inline   bare + AI CLIs (editor-adjacent / "inline" assistance)
+#   agentic  inline + everything needed to run agents locally
+#
+# Because they nest, a role never asks "which profile exactly?" -- it asks
+# "is feature X in scope at or below the selected tier?". `profile_rank`
+# turns the name into an ordinal so `>=` comparisons work.
+profile: bare
+
+profile_ranks:
+  bare: 0
+  inline: 1
+  agentic: 2
+
+# .get() so an unknown profile resolves to -1 instead of raising, letting the
+# assert in site.yml report a clean error message.
+profile_rank: "{{ profile_ranks.get(profile, -1) }}"
+
+# Convenience predicate used by the packages role. AI CLIs come in at `inline`.
+want_ai_clis: "{{ profile_rank | int >= profile_ranks.inline }}"

--- a/provision/inventory/hosts.yml
+++ b/provision/inventory/hosts.yml
@@ -1,0 +1,11 @@
+---
+# Single-host inventory: this machine, provisioned in place.
+#
+# Layer 1 is "configure the box you are on", so there is exactly one host and
+# the connection is local (no SSH round-trip to localhost). Remote fleets, if
+# they ever happen, would be a separate inventory file -- not a reason to
+# complicate this one.
+all:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/provision/roles/packages/README.md
+++ b/provision/roles/packages/README.md
@@ -1,0 +1,46 @@
+# role: packages
+
+Installs OS packages from the repo's existing manifests, plus profile-gated
+AI CLIs. Keeps **no package list of its own** — the manifests at the repo root
+stay the single source of truth.
+
+## What it does
+
+| OS family | Task file      | Reads               | Verified?                         |
+| --------- | -------------- | ------------------- | --------------------------------- |
+| Debian    | `tasks/apt.yml` | `packages/apt.txt`  | yes — `--check --diff` on WSL     |
+| Darwin    | `tasks/homebrew.yml` | `packages/Brewfile` | **no** — written, never executed |
+| (any)     | `tasks/ai_clis.yml` | pinned in `defaults/main.yml` | `claude` + `copilot`, WSL |
+
+winget / `packages/winget.txt` is intentionally not consumed — Phase 3.
+
+## Profile gating
+
+`tasks/ai_clis.yml` is imported only when `want_ai_clis` is true, which
+`inventory/group_vars/all.yml` defines as `profile_rank >= inline`. So:
+
+- `profile=bare` → apt/brew only, no AI CLIs
+- `profile=inline` / `profile=agentic` → apt/brew + `claude` + `copilot`
+
+## Key variables (`defaults/main.yml`)
+
+| Variable                       | Default | Purpose                                             |
+| ------------------------------ | ------- | -------------------------------------------------- |
+| `packages_apt_become`          | `true`  | set `false` to dry-run without passwordless sudo   |
+| `packages_apt_update_cache`    | `true`  | set `false` to dry-run without root                |
+| `packages_apt_exclude`         | `[]`    | apt.txt entries this host sources elsewhere (e.g. `nodejs`/`npm` via nvm) |
+| `packages_copilot_cli_version` | pinned  | keep in lockstep with `install.py`                 |
+
+`packages_apt_exclude` defaults to empty on purpose: drift between `apt.txt`
+and what a machine actually has should be *visible* in `--check --diff`, not
+silently masked. Only pin it per-host when a divergence is deliberate and
+permanent.
+
+## Manifest parsing
+
+- `apt.txt`: strip `#` comments (inline + full-line), trim, drop blanks.
+- `Brewfile`: `regex_findall` for `^tap "…"`, `^brew "…"`, `^cask "…"`;
+  trailing `# comments` are ignored by the pattern.
+
+Neither parser re-lists packages — they read the file byte-for-byte via
+`slurp` at play time.

--- a/provision/roles/packages/defaults/main.yml
+++ b/provision/roles/packages/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+# ── Source-of-truth manifests ────────────────────────────────────────────────
+# The role does NOT keep its own package lists. It reads the manifests that
+# already live at the repo root and that install.py / install.ps1 consume
+# today, so there is exactly one place to edit a package.
+#
+#   packages/apt.txt   -> Debian/Ubuntu (apt)          [verified on WSL]
+#   packages/Brewfile  -> macOS (Homebrew)             [written, UNVERIFIED]
+#   packages/winget.txt -> Windows (winget)            [Phase 3, not built]
+#
+# playbook_dir is .../provision, so the repo root is one level up.
+packages_repo_root: "{{ playbook_dir }}/.."
+packages_apt_manifest: "{{ packages_repo_root }}/packages/apt.txt"
+packages_brewfile: "{{ packages_repo_root }}/packages/Brewfile"
+
+# ── apt behaviour ────────────────────────────────────────────────────────────
+# Real provisioning runs need root to install and to refresh the apt cache.
+# Both are knobs so the play can be dry-run on a box without passwordless
+# sudo (see roles/packages/README.md -> "Verifying on WSL").
+packages_apt_become: true
+packages_apt_update_cache: true
+packages_apt_cache_valid_time: 3600
+
+# Packages listed in apt.txt that this particular machine deliberately gets
+# from somewhere else (e.g. nodejs/npm via nvm rather than apt). Empty by
+# default: the manifest is the source of truth and drift should be visible,
+# not silently masked. Set per-host in inventory when a divergence is
+# intentional and permanent.
+packages_apt_exclude: []
+
+# ── AI CLI pins ──────────────────────────────────────────────────────────────
+# Kept in lockstep with the constants at the top of install.py.
+packages_copilot_cli_version: "1.0.80"
+
+# Claude Code has no pinned version in install.py (it self-updates from the
+# tarball installer); the role only ensures it is present.
+packages_claude_installer_url: "https://claude.ai/install.sh"

--- a/provision/roles/packages/meta/main.yml
+++ b/provision/roles/packages/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  role_name: packages
+  namespace: dotfiles
+  author: dotfiles maintainers
+  description: >-
+    Install OS packages from the repo's existing manifests (packages/apt.txt,
+    packages/Brewfile) plus profile-gated AI CLIs.
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Ubuntu
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: MacOSX
+      versions: [all]
+
+# community.general provides the homebrew* modules used by the macOS branch.
+# It ships with the `ansible` package (pipx install --include-deps ansible);
+# listed here so `ansible-galaxy role install` / lint knows about it.
+collections:
+  - community.general
+
+dependencies: []

--- a/provision/roles/packages/tasks/ai_clis.yml
+++ b/provision/roles/packages/tasks/ai_clis.yml
@@ -1,7 +1,8 @@
 ---
-# Only imported when want_ai_clis is true (profile >= inline; see
-# inventory/group_vars/all.yml). Under profile=bare this file never runs, which
-# is the whole point of the nesting: bare ⊂ inline ⊂ agentic.
+# Only imported when want_ai_clis is true (profile >= inline; the fact is set
+# in ../../../site.yml from the shared reader profile/profile.py). Under
+# profile=bare this file never runs, which is the whole point of the nesting:
+# bare ⊂ inline ⊂ agentic.
 #
 # Mirrors the two AI CLIs install.py installs on Linux:
 #   claude   -> official tarball installer (self-updating, unpinned upstream)

--- a/provision/roles/packages/tasks/ai_clis.yml
+++ b/provision/roles/packages/tasks/ai_clis.yml
@@ -1,0 +1,36 @@
+---
+# Only imported when want_ai_clis is true (profile >= inline; see
+# inventory/group_vars/all.yml). Under profile=bare this file never runs, which
+# is the whole point of the nesting: bare ⊂ inline ⊂ agentic.
+#
+# Mirrors the two AI CLIs install.py installs on Linux:
+#   claude   -> official tarball installer (self-updating, unpinned upstream)
+#   copilot  -> npm global @github/copilot, version-pinned
+#
+# Kilo Code would slot in here the same way (npm global @kilocode/cli); it is
+# left out of this spike because the brief scopes AI CLIs to claude + copilot.
+
+- name: Check whether Claude Code is already on PATH
+  ansible.builtin.command: sh -c 'command -v claude'
+  register: _packages_claude_present
+  changed_when: false
+  failed_when: false
+  check_mode: false # read-only probe; safe to run during --check
+
+- name: Install Claude Code via the official installer
+  ansible.builtin.shell: >-
+    set -o pipefail &&
+    curl -fsSL {{ packages_claude_installer_url | quote }} | bash
+  args:
+    executable: /bin/bash
+  when: _packages_claude_present.rc != 0
+  # This task only runs when `claude` is absent, so running it is itself the
+  # change. (command/shell are skipped under --check regardless.)
+  changed_when: true
+
+- name: Ensure GitHub Copilot CLI is installed (npm global, pinned)
+  community.general.npm:
+    name: "@github/copilot"
+    version: "{{ packages_copilot_cli_version }}"
+    global: true
+    state: present

--- a/provision/roles/packages/tasks/apt.yml
+++ b/provision/roles/packages/tasks/apt.yml
@@ -1,0 +1,34 @@
+---
+# Debian/Ubuntu/WSL branch. Source of truth is packages/apt.txt at the repo
+# root -- the same file `xargs sudo apt-get install` consumes today.
+
+- name: Read the apt manifest (packages/apt.txt)
+  ansible.builtin.slurp:
+    src: "{{ packages_apt_manifest }}"
+  register: _packages_apt_raw
+
+- name: Resolve the apt manifest to a package list
+  ansible.builtin.set_fact:
+    # Strip inline/full-line "#" comments, trim, drop blanks, drop anything
+    # this host intentionally sources elsewhere (packages_apt_exclude).
+    packages_apt_wanted: >-
+      {{
+        (_packages_apt_raw.content | b64decode).splitlines()
+        | map('regex_replace', '#.*$', '')
+        | map('trim')
+        | reject('equalto', '')
+        | reject('in', packages_apt_exclude)
+        | list
+      }}
+
+- name: Show the resolved apt package list
+  ansible.builtin.debug:
+    var: packages_apt_wanted
+
+- name: Ensure apt packages from packages/apt.txt are present
+  become: "{{ packages_apt_become | bool }}"
+  ansible.builtin.apt:
+    name: "{{ packages_apt_wanted }}"
+    state: present
+    update_cache: "{{ packages_apt_update_cache | bool }}"
+    cache_valid_time: "{{ packages_apt_cache_valid_time | int }}"

--- a/provision/roles/packages/tasks/apt.yml
+++ b/provision/roles/packages/tasks/apt.yml
@@ -21,6 +21,26 @@
         | list
       }}
 
+- name: Fail if any apt manifest entry is not package-name shaped
+  # Entries go to ansible.builtin.apt as an argv list, not through a shell, so
+  # this is defence in depth: a line beginning with "-" (e.g. "-o", "--reinstall")
+  # would still be read by apt-get as an OPTION rather than a package name. Fail
+  # loudly and name the offender rather than silently dropping or passing it.
+  ansible.builtin.assert:
+    that:
+      - _packages_apt_malformed | length == 0
+    fail_msg: >-
+      packages/apt.txt has {{ _packages_apt_malformed | length }} entry/entries
+      that are not valid package names (each must match
+      '^[a-z0-9][a-z0-9+._-]*$'): {{ _packages_apt_malformed | join(', ') }}
+    success_msg: >-
+      All {{ packages_apt_wanted | length }} apt manifest entries are
+      package-name shaped.
+    quiet: true
+  vars:
+    _packages_apt_malformed: >-
+      {{ packages_apt_wanted | reject('match', '^[a-z0-9][a-z0-9+._-]*$') | list }}
+
 - name: Show the resolved apt package list
   ansible.builtin.debug:
     var: packages_apt_wanted

--- a/provision/roles/packages/tasks/homebrew.yml
+++ b/provision/roles/packages/tasks/homebrew.yml
@@ -1,0 +1,53 @@
+---
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │  WRITTEN BUT UNVERIFIED ON macOS.                                        │
+# │  No Mac was reachable from the environment this role was spiked in, so   │
+# │  this branch has never actually run. Do not treat it as tested. The      │
+# │  first person with a Mac should dry-run `site.yml --check --diff` and    │
+# │  report back before this is trusted.                                     │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+# community.general ships homebrew / homebrew_cask / homebrew_tap but NO
+# Brewfile-native module, so the role parses packages/Brewfile itself and
+# drives the three modules that do exist. (See provision/README.md ->
+# "Upstream-contribution candidates".)
+
+- name: Read the Brewfile (packages/Brewfile)
+  ansible.builtin.slurp:
+    src: "{{ packages_brewfile }}"
+  register: _packages_brewfile_raw
+
+- name: Decode the Brewfile
+  ansible.builtin.set_fact:
+    _packages_brew_text: "{{ _packages_brewfile_raw.content | b64decode }}"
+
+- name: Extract taps / formulae / casks from the Brewfile
+  ansible.builtin.set_fact:
+    packages_brew_taps: "{{ _packages_brew_text | regex_findall('(?m)^tap\\s+\"([^\"]+)\"') }}"
+    packages_brew_formulae: "{{ _packages_brew_text | regex_findall('(?m)^brew\\s+\"([^\"]+)\"') }}"
+    packages_brew_casks: "{{ _packages_brew_text | regex_findall('(?m)^cask\\s+\"([^\"]+)\"') }}"
+
+- name: Show what the Brewfile resolves to
+  ansible.builtin.debug:
+    msg:
+      taps: "{{ packages_brew_taps }}"
+      formulae: "{{ packages_brew_formulae }}"
+      casks: "{{ packages_brew_casks }}"
+
+- name: Ensure Homebrew taps from the Brewfile are present
+  community.general.homebrew_tap:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ packages_brew_taps }}"
+
+- name: Ensure Homebrew formulae from the Brewfile are present
+  community.general.homebrew:
+    name: "{{ packages_brew_formulae }}"
+    state: present
+  when: packages_brew_formulae | length > 0
+
+- name: Ensure Homebrew casks from the Brewfile are present
+  community.general.homebrew_cask:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ packages_brew_casks }}"

--- a/provision/roles/packages/tasks/main.yml
+++ b/provision/roles/packages/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# Dispatch on OS family. Each branch reads the matching manifest from the repo
+# root; none of them re-list packages here.
+
+- name: Install apt packages (Debian / Ubuntu / WSL)
+  ansible.builtin.import_tasks: apt.yml
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Install Homebrew packages (macOS)
+  ansible.builtin.import_tasks: homebrew.yml
+  when: ansible_facts['os_family'] == 'Darwin'
+
+# winget / Windows is Phase 3. packages/winget.txt is intentionally left
+# unconsumed here; see roles/packages/README.md.
+
+- name: Install profile-gated AI CLIs
+  ansible.builtin.import_tasks: ai_clis.yml
+  when: want_ai_clis | bool

--- a/provision/site.yml
+++ b/provision/site.yml
@@ -1,13 +1,27 @@
 ---
 # Layer 1 entry point: machine state via Ansible.
 #
-#   ansible-playbook site.yml -e profile=bare
+#   ansible-playbook site.yml                     # profile from the shared file
+#   ansible-playbook site.yml -e profile=bare     # explicit override
 #   ansible-playbook site.yml -e profile=inline
 #   ansible-playbook site.yml -e profile=agentic
 #
 # Always safe to dry-run first:
 #
-#   ansible-playbook site.yml -e profile=inline --check --diff
+#   ansible-playbook site.yml --check --diff
+#
+# The profile itself (bare ⊂ inline ⊂ agentic, the rank order, the "file
+# absent ⇒ agentic" default, and every validation rule) is defined once, in
+# profile/ at the repo root (PR #53). This play does not parse the profile
+# file — it shells out to the shared reader exactly as profile/README.md
+# documents for Ansible:
+#
+#   * `python3 profile/profile.py`               -> resolved name on stdout
+#   * `python3 profile/profile.py --at-least X`  -> rc 0/1 gate, rc 2 = broken
+#
+# An explicit `-e profile=<tier>` wins over the file; anything else is read
+# from the file. An invalid value (in the file, or passed with -e) fails the
+# play here, loudly, before any package work happens.
 #
 # This spike wires up exactly one role (`packages`). Later layers/roles
 # (shell, git config, editor, secrets plumbing) hang off this same play.
@@ -17,19 +31,74 @@
   gather_facts: true
 
   vars:
-    # Overridable on the command line with -e profile=<tier>.
-    profile: bare
+    # Repo root: playbook_dir is .../provision, the shared reader is one level
+    # up under profile/. Matches roles/packages/defaults/main.yml.
+    dotfiles_dir: "{{ playbook_dir }}/.."
+    # `profile` is intentionally NOT defaulted. Undefined  -> read the shared
+    # file (contract default when the file is absent: agentic). Defined via
+    # `-e profile=<tier>` -> that value wins.
 
   pre_tasks:
-    - name: Validate the requested profile
-      ansible.builtin.assert:
-        that:
-          - profile in profile_ranks
-        fail_msg: >-
-          Unknown profile {{ profile | to_json }}.
-          Pass -e profile=<{{ profile_ranks.keys() | join('|') }}>.
-        success_msg: "profile = {{ profile }} (rank {{ profile_rank }})"
-        quiet: true
+    - name: Resolve the active profile from the shared reader (no -e override)
+      ansible.builtin.command:
+        cmd: python3 {{ dotfiles_dir }}/profile/profile.py
+      register: _dotfiles_profile_read
+      changed_when: false
+      failed_when: _dotfiles_profile_read.rc != 0
+      check_mode: false # read-only: the reader only reads the profile file
+      when: profile is not defined
+
+    - name: Validate an explicit -e profile= override via the shared reader
+      # `--at-least <name>` exits 2 on an unknown profile name, which is how a
+      # typo in `-e profile=` is surfaced without re-encoding the profile list
+      # here. rc 0/1 (override is a real tier) both pass. XDG_CONFIG_HOME is
+      # pointed at a guaranteed-absent path so the reader resolves the "file"
+      # to the default and this task validates *only* the -e token -- an
+      # explicit override must not be held hostage to a broken on-disk file.
+      ansible.builtin.command:
+        cmd: python3 {{ dotfiles_dir }}/profile/profile.py --at-least {{ profile }}
+      environment:
+        XDG_CONFIG_HOME: /nonexistent
+      register: _dotfiles_profile_override_check
+      changed_when: false
+      failed_when: _dotfiles_profile_override_check.rc == 2
+      check_mode: false # read-only name check via the shared reader
+      when: profile is defined
+
+    - name: Record the resolved profile (from the shared reader)
+      ansible.builtin.set_fact:
+        dotfiles_profile: "{{ _dotfiles_profile_read.stdout | trim }}"
+      when: profile is not defined
+
+    - name: Record the resolved profile (from the -e profile= override)
+      ansible.builtin.set_fact:
+        dotfiles_profile: "{{ profile }}"
+      when: profile is defined
+
+    - name: Announce the resolved profile
+      ansible.builtin.debug:
+        msg: "profile = {{ dotfiles_profile }}"
+
+    - name: Decide whether AI CLIs are in scope (reader gate, no -e override)
+      # 0 = at least inline, 1 = below inline, 2 = broken profile file.
+      ansible.builtin.command:
+        cmd: python3 {{ dotfiles_dir }}/profile/profile.py --at-least inline
+      register: _dotfiles_profile_at_least_inline
+      changed_when: false
+      failed_when: _dotfiles_profile_at_least_inline.rc == 2
+      check_mode: false # read-only gate query via the shared reader
+      when: profile is not defined
+
+    - name: Set want_ai_clis from the reader gate
+      ansible.builtin.set_fact:
+        want_ai_clis: "{{ _dotfiles_profile_at_least_inline.rc == 0 }}"
+      when: profile is not defined
+
+    - name: Set want_ai_clis from the -e profile= override
+      # AI CLIs come in at inline and above; bare is the only tier without them.
+      ansible.builtin.set_fact:
+        want_ai_clis: "{{ dotfiles_profile in ['inline', 'agentic'] }}"
+      when: profile is defined
 
   roles:
     - role: packages

--- a/provision/site.yml
+++ b/provision/site.yml
@@ -1,0 +1,35 @@
+---
+# Layer 1 entry point: machine state via Ansible.
+#
+#   ansible-playbook site.yml -e profile=bare
+#   ansible-playbook site.yml -e profile=inline
+#   ansible-playbook site.yml -e profile=agentic
+#
+# Always safe to dry-run first:
+#
+#   ansible-playbook site.yml -e profile=inline --check --diff
+#
+# This spike wires up exactly one role (`packages`). Later layers/roles
+# (shell, git config, editor, secrets plumbing) hang off this same play.
+
+- name: Provision machine state
+  hosts: all
+  gather_facts: true
+
+  vars:
+    # Overridable on the command line with -e profile=<tier>.
+    profile: bare
+
+  pre_tasks:
+    - name: Validate the requested profile
+      ansible.builtin.assert:
+        that:
+          - profile in profile_ranks
+        fail_msg: >-
+          Unknown profile {{ profile | to_json }}.
+          Pass -e profile=<{{ profile_ranks.keys() | join('|') }}>.
+        success_msg: "profile = {{ profile }} (rank {{ profile_rank }})"
+        quiet: true
+
+  roles:
+    - role: packages


### PR DESCRIPTION
## What

Spike of **Layer 1** of the provisioning split: machine state via Ansible.
This is an additive monorepo change — a new top-level `provision/` directory,
nothing outside it is touched.

Scope is deliberately one role (`packages`) plus the skeleton around it, to
prove the shape of Layer 1 before the rest of `install.py` is ported.
Ansible-vs-Nix is already decided; this does not reopen it.

```
provision/
├── ansible.cfg                     local connection, single host, no vault
├── inventory/
│   ├── hosts.yml                   one host: localhost, connection=local
│   └── group_vars/all.yml          profile tiers: bare ⊂ inline ⊂ agentic
├── site.yml                        entry point; -e profile=<bare|inline|agentic>
└── roles/packages/                 apt + homebrew + AI-CLI tasks
```

## Source of truth

The role keeps **no package lists of its own**. It reads the manifests that
already exist at the repo root:

| Manifest              | Branch                | Status |
| --------------------- | --------------------- | ------ |
| `packages/apt.txt`    | `tasks/apt.yml`       | verified on WSL |
| `packages/Brewfile`   | `tasks/homebrew.yml`  | **written, UNVERIFIED on macOS** |
| `packages/winget.txt` | —                     | Phase 3, not consumed |

## Profiles

Strictly nested: `bare ⊂ inline ⊂ agentic`. `tasks/ai_clis.yml` (`claude` +
`copilot`) is imported only when the profile is `inline` or higher. `bare`
installs packages only. An unknown `-e profile=` value fails in `pre_tasks`
before any package work.

## macOS is written but NOT verified

There is no Mac reachable from the environment this was spiked in.
`tasks/homebrew.yml` has never executed — do not read it as tested, and this
PR is not cross-platform parity. The Brewfile *parser* is verified (it
extracts 1 tap / 26 formulae / 7 casks from the real file); the
`community.general.homebrew*` module calls behind it are unverified. macOS
verification is deferred.

The winget/Windows branch is deferred to Phase 3 and is not built here.

## Verification (WSL, Debian 13, ansible-core 2.21.3)

- `ansible-playbook site.yml --syntax-check` → rc=0
- `ansible-lint` at the `production` profile → 0 failures, 0 warnings
- `site.yml --check --diff` for `bare` / `inline` / `agentic`: clean **except**
  the apt task wants to install `nodejs` + `npm` (and their dependency tree),
  because `packages/apt.txt` declares them but this machine sources Node from
  `nvm`. With those two excluded via the role's built-in
  `packages_apt_exclude`, the run is fully clean: `ok=8 changed=0 failed=0`.
  The AI-CLI tasks (`claude` presence check, `copilot` npm pin at 1.0.80)
  report no change.

Full `--check --diff` output is in the task report accompanying this PR.

### Environment gaps found while verifying (candidates to fix in bootstrap/CI)

- `python3-apt` is absent on the reference WSL box; `ansible.builtin.apt`
  refuses check mode without it and it is not pip-installable. Worked around
  for verification only (staged the distro package on `PYTHONPATH`); not part
  of the role.
- No passwordless sudo on the box, so the dry run needed
  `-e packages_apt_become=false -e packages_apt_update_cache=false`. The role
  defaults (`become: true`, `update_cache: true`) are correct for a real run.

## Upstream-contribution candidates

- `community.general` has **no Brewfile-native module** (`homebrew`,
  `homebrew_cask`, `homebrew_tap` exist; no `homebrew_bundle`). The role
  parses the Brewfile itself as a result. A first-class `homebrew_bundle`
  with check-mode/diff support is worth proposing upstream.
- `ansible.builtin.apt` check-mode hard-depends on `python3-apt` with only a
  runtime error for guidance — poor ergonomics on a fresh WSL/Debian box.
  Worth a docs/UX issue upstream.

## Not in this PR (by design)

`bootstrap/` and `dotfiles/` layers; any role other than `packages`; the
winget branch; porting the rest of `install.py`.



---
Part of #36 (Phase 0: the Ansible spike half; the profile contract half landed in #53). Epic #35.
