### PR TITLE
fix(hooks): auto-run the installer only on the default branch

### DIFF
--- a/hooks/_dispatch.sh
+++ b/hooks/_dispatch.sh
@@ -167,6 +167,58 @@ if [ "$CMP_RECORDED" != "$CMP_DOTFILES" ]; then
   exit 0
 fi
 
+# Default-branch guard — the receipt check above only proves this IS the
+# canonical checkout; it does nothing about *which branch* is checked out.
+# In the canonical checkout the receipt legitimately equals --show-toplevel,
+# so without this the installer fires on ANY branch switch. install.py's
+# render() rewrites $HOME/.gitconfig and $HOME/.ssh/config unconditionally
+# (not only on content change), so a feature-branch checkout demonstrably
+# mutates the real home directory — and once installer behaviour starts
+# differing branch to branch that stops being benign. See issue #54.
+#
+# Policy: auto-sync only when HEAD is on the repo's default branch. A
+# deliberate `git checkout <default>` or a `git pull` on it still installs;
+# checking out a feature branch to inspect it does not.
+#
+# "Default branch" is derived dynamically from refs/remotes/origin/HEAD
+# (origin/main -> main), never hardcoded to "main" — hardcoding is brittle
+# across forks and branch renames. Older clones (the canonical checkout is
+# one) never recorded origin/HEAD locally; a one-shot `git remote set-head
+# origin --auto` repairs and persists it, so the network round-trip happens
+# at most once. If it still can't be resolved (offline, no origin), fail
+# closed and skip — never guess.
+#
+# A detached HEAD has no current branch: `git symbolic-ref --short HEAD`
+# fails, which falls through to the same skip. That is the intended
+# behaviour — a detached HEAD is an inspect/bisect/CI state, never the
+# "sync my dotfiles" case.
+#
+# Shared by post-checkout, post-merge and post-rewrite: the same gate is
+# correct for all three. `git pull` on the default branch (which rewrites
+# commits here, since this repo sets pull.rebase=true, firing post-rewrite)
+# still installs; a rebase or amend while on a feature branch does not.
+DEFAULT_REF="$(git -C "$DOTFILES_DIR" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
+if [ -z "$DEFAULT_REF" ]; then
+  GIT_TERMINAL_PROMPT=0 git -C "$DOTFILES_DIR" remote set-head origin --auto >/dev/null 2>&1 || true
+  DEFAULT_REF="$(git -C "$DOTFILES_DIR" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
+fi
+DEFAULT_BRANCH="${DEFAULT_REF#refs/remotes/origin/}"
+if [ -z "$DEFAULT_BRANCH" ]; then
+  echo "dotfiles: could not determine the default branch — refs/remotes/origin/HEAD is unset and 'git remote set-head origin --auto' could not repair it — skipping hook-triggered install (fail closed; run 'git remote set-head origin --auto' here, then 'bash install.sh' by hand to re-arm)"
+  exit 0
+fi
+
+CURRENT_BRANCH="$(git -C "$DOTFILES_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+if [ -z "$CURRENT_BRANCH" ]; then
+  echo "dotfiles: this git operation is on a detached HEAD, not the default branch '$DEFAULT_BRANCH' — skipping hook-triggered install (only the default branch auto-syncs \$HOME)"
+  exit 0
+fi
+
+if [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
+  echo "dotfiles: this git operation is on branch '$CURRENT_BRANCH', not the default branch '$DEFAULT_BRANCH' — skipping hook-triggered install (only the default branch auto-syncs \$HOME; run 'bash install.sh' here by hand if you meant to)"
+  exit 0
+fi
+
 case "$UNAME_S" in
   MINGW*|MSYS*)
     command -v pwsh >/dev/null 2>&1 && pwsh -NoLogo -NoProfile -File "$DOTFILES_DIR/install.ps1" -SkipWSL


### PR DESCRIPTION
## What

Follow-up to PR #59, completing the remaining half of issue #54.

#59 closed the *other-tree* class (linked worktrees, `git worktree add`, clones carrying `core.hooksPath`, cwd/tree divergence) by authenticating `git rev-parse --show-toplevel` against the install receipt. What it left open by design: **in the canonical checkout the receipt legitimately equals `--show-toplevel`**, so `hooks/_dispatch.sh` runs `install.sh` on *any* branch checkout, merge or rebase.

That matters because `install.py`'s `render()` rewrites `$HOME/.gitconfig` and `$HOME/.ssh/config` **unconditionally** — not only on content change — so a feature-branch checkout in the canonical checkout demonstrably changes the mtimes of the real home-directory files even when the rendered bytes are identical. Once Phase 2 (#39, #40) makes installer behaviour differ branch to branch, that stops being benign.

## Change

One file: `hooks/_dispatch.sh`. A new guard, placed **after** the receipt/toplevel check and **before** the installer dispatch: auto-sync only when `HEAD` is on the repo's default branch.

- `git checkout <default>` / `git pull` on the default branch → still installs (this path is preserved).
- `git checkout <feature-branch>` in the canonical checkout → inert, prints a **distinct** skip diagnostic naming the current branch and the default branch.

### Semantics decisions (the "decide and document" item from #54)

**"Default branch" is derived dynamically** from `git symbolic-ref refs/remotes/origin/HEAD` (`refs/remotes/origin/main` → `main`), never hardcoded to `main` — hardcoding is brittle across forks and branch renames. Older clones (the canonical checkout is one — it has no `refs/remotes/origin/HEAD`) never recorded it locally, so the guard attempts a one-shot `git remote set-head origin --auto` (with `GIT_TERMINAL_PROMPT=0`), which repairs and persists the ref so the network round-trip happens at most once. If it still cannot be resolved (offline, no `origin`), the guard **fails closed and skips** with its own diagnostic.

**Detached HEAD is treated as non-default → skip.** `git symbolic-ref --short HEAD` fails on a detached HEAD, which falls through to a dedicated skip diagnostic. A detached HEAD is an inspect/bisect/CI state, never the "sync my dotfiles" case.

**`post-rewrite` (rebase/amend):** the same gate applies to all three of `post-checkout`, `post-merge`, `post-rewrite`. A `git pull` on the default branch rewrites commits here (this repo sets `pull.rebase=true`) and fires `post-rewrite` — that still installs. A rebase or amend while on a feature branch does not.

Every pre-existing guard behaviour is preserved: missing receipt → skip; receipt/toplevel mismatch → skip; toplevel undeterminable → skip; the `MINGW*|MSYS*` path normalisation on both sides; `post-checkout`'s `$3 = 1` gating.

## Verification

A faithful `/tmp` harness — a clone configured to mimic the canonical setup (absolute `core.hooksPath`, an install receipt naming the clone, a stand-in `$HOME`) — exercising the **real** `hooks/_dispatch.sh` and the **real** `install.sh`. Before/after mtimes of the stand-in `~/.gitconfig` and `~/.ssh/config` for every case:

| Case | Result | mtimes |
|---|---|---|
| checkout **feature** branch | `dotfiles: this git operation is on branch 'feat/harness', not the default branch 'main' — skipping...` | unchanged |
| checkout **detached HEAD** | `dotfiles: this git operation is on a detached HEAD, not the default branch 'main' — skipping...` | unchanged |
| checkout **default** branch | installer runs (`rendered ~/.gitconfig`, `rendered ~/.ssh/config`) | **changed** |
| receipt **missing** | `dotfiles: no install receipt at ... — skipping...` | unchanged |
| receipt/toplevel **mismatch** | `dotfiles: install receipt points at '...', but this git operation is on working tree '...' — skipping...` | unchanged |
| default branch **undeterminable** | `dotfiles: could not determine the default branch — refs/remotes/origin/HEAD is unset and 'git remote set-head origin --auto' could not repair it — skipping...` | unchanged |

Local gates, all green: `shellcheck --severity=warning` on `hooks/_dispatch.sh`; `bash -n` on every tracked shell script; `python3 -m py_compile install.py`; `hooks/pre-commit` (spine drift + never-merge invariant).

The true canonical-checkout confirmation is deliberately **not** done here — it can only happen after this merges and the canonical checkout is armed. That remains outstanding, as noted in #54.

Part of #54.